### PR TITLE
Add name of affected project in mail subject

### DIFF
--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -81,7 +81,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(NotificationGroup.NEW_VULNERABILITY)
-                    .title(NotificationConstants.Title.NEW_VULNERABILITY)
+                    .title(generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABILITY, new HashSet<>(affectedProjects.values())))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(detachedVuln))
                     .subject(new NewVulnerabilityIdentified(detachedVuln, detachedComponent, new HashSet<>(affectedProjects.values())))
@@ -98,7 +98,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(NotificationGroup.NEW_VULNERABLE_DEPENDENCY)
-                    .title(NotificationConstants.Title.NEW_VULNERABLE_DEPENDENCY)
+                    .title(generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABLE_DEPENDENCY, component.getProject()))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(component, vulnerabilities))
                     .subject(new NewVulnerableDependency(component, vulnerabilities))
@@ -148,7 +148,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(notificationGroup)
-                    .title(title)
+                    .title(generateNotificationTitle(title, affectedProjects))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(analysis))
                     .subject(new AnalysisDecisionChange(analysis.getVulnerability(),
@@ -187,7 +187,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(notificationGroup)
-                    .title(title)
+                    .title(generateNotificationTitle(title, violationAnalysis.getProject()))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(violationAnalysis))
                     .subject(new ViolationAnalysisDecisionChange(violationAnalysis.getPolicyViolation(),
@@ -206,7 +206,7 @@ public final class NotificationUtil {
         Notification.dispatch(new Notification()
                 .scope(NotificationScope.PORTFOLIO)
                 .group(NotificationGroup.POLICY_VIOLATION)
-                .title(NotificationConstants.Title.POLICY_VIOLATION)
+                .title(generateNotificationTitle(NotificationConstants.Title.POLICY_VIOLATION,policyViolation.getProject()))
                 .level(NotificationLevel.INFORMATIONAL)
                 .content(generateNotificationContent(pv))
                 .subject(new PolicyViolationIdentified(pv, pv.getComponent(), pv.getProject()))
@@ -495,5 +495,19 @@ public final class NotificationUtil {
 
     private static String generateNotificationContent(final ViolationAnalysis violationAnalysis) {
         return "An violation analysis decision was made to a policy violation affecting a project";
+    }
+
+    private static String generateNotificationTitle(String messageType, Project project){
+        return messageType + " on Project: " + project.toString();
+    }
+
+    private static String generateNotificationTitle(String messageType, Set<Project> affectedProjects){
+        if (affectedProjects.size() == 1){
+            return messageType + " on Project: " + affectedProjects;
+        }else if (affectedProjects.size() > 1){
+            return messageType + " on multiple Projects";
+        }else {
+            return "";
+        }
     }
 }

--- a/src/main/resources/templates/notification/publisher/email.peb
+++ b/src/main/resources/templates/notification/publisher/email.peb
@@ -8,6 +8,11 @@ Severity:          {{ subject.vulnerability.severity }}
 Source:            {{ subject.vulnerability.source }}
 Component:         {{ subject.component.toString }}
 Component URL:     {{ baseUrl }}/component/?uuid={{ subject.component.uuid }}
+Affected Projects:
+{% for affectedProject in notification.subject.affectedProjects %}
+Project:           [{{ affectedProject.name }} : {{ affectedProject.version }}]
+Project URL:       {{ baseUrl }}/project/?uuid={{ affectedProject.uuid }}
+{% endfor %}
 {% elseif notification.group == "NEW_VULNERABLE_DEPENDENCY" %}
 Project:           {{ subject.dependency.project.toString }}
 Project URL:       {{ baseUrl }}/project/?uuid={{ subject.dependency.project.uuid }}
@@ -34,8 +39,11 @@ Severity:          {{ subject.vulnerability.severity }}
 Source:            {{ subject.vulnerability.source }}
 Component:         {{ subject.component.toString }}
 Component URL:     {{ baseUrl }}/component/?uuid={{ subject.component.uuid }}
-Project:           {{ subject.project.toString }}
-Project URL:       {{ baseUrl }}/project/?uuid={{ subject.project.uuid }}
+Affected Projects:
+{% for affectedProject in notification.subject.affectedProjects %}
+Project:            [{{ affectedProject.name }} : {{ affectedProject.version }}]
+Project URL:        {{ baseUrl }}/project/?uuid={{ affectedProject.uuid }}
+    {% endfor %}
 {% elseif notification.group == "BOM_CONSUMED" %}
 Project:           {{ subject.project.name }}
 Version:           {{ subject.project.version }}


### PR DESCRIPTION
The information displayed by an email notification makes it hard to quickly gather the needed information from it:

- The subject line does only inform about the type of notification (e.g. `New Vulnerability Identified`) but does not state which project is affected, making it hard to distinguish notifications and requires the user to look for affected projects in the notification body.
- More than one project can be affected by a `NEW_VULNERABILITY_IDENTIFIED` or  `GLOBAL_AUDIT_CHANGE` but the notification does not show any or only one affected project.

The subject line now states which project is affected or if multiple projects are affected to provide more quick-to-get information and to make emails more distinguishable .
Email notifications for `NEW_VULNERABILITY_IDENTIFIED` and  `GLOBAL_AUDIT_CHANGE` now include the name, version and URL for every affected project.

Signed-off-by: rbt-mm <rbt@mm-software.com>