### PR TITLE
Add project in mail subject

### DIFF
--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -81,7 +81,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(NotificationGroup.NEW_VULNERABILITY)
-                    .title(NotificationConstants.Title.NEW_VULNERABILITY)
+                    .title(generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABILITY, new HashSet<>(affectedProjects.values())))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(detachedVuln))
                     .subject(new NewVulnerabilityIdentified(detachedVuln, detachedComponent, new HashSet<>(affectedProjects.values())))
@@ -98,7 +98,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(NotificationGroup.NEW_VULNERABLE_DEPENDENCY)
-                    .title(NotificationConstants.Title.NEW_VULNERABLE_DEPENDENCY)
+                    .title(generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABLE_DEPENDENCY, component.getProject()))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(component, vulnerabilities))
                     .subject(new NewVulnerableDependency(component, vulnerabilities))
@@ -148,7 +148,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(notificationGroup)
-                    .title(title)
+                    .title(generateNotificationTitle(title, affectedProjects))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(analysis))
                     .subject(new AnalysisDecisionChange(analysis.getVulnerability(),
@@ -187,7 +187,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(notificationGroup)
-                    .title(title)
+                    .title(generateNotificationTitle(title, violationAnalysis.getProject()))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(violationAnalysis))
                     .subject(new ViolationAnalysisDecisionChange(violationAnalysis.getPolicyViolation(),
@@ -206,7 +206,7 @@ public final class NotificationUtil {
         Notification.dispatch(new Notification()
                 .scope(NotificationScope.PORTFOLIO)
                 .group(NotificationGroup.POLICY_VIOLATION)
-                .title(NotificationConstants.Title.POLICY_VIOLATION)
+                .title(generateNotificationTitle(NotificationConstants.Title.POLICY_VIOLATION,policyViolation.getProject()))
                 .level(NotificationLevel.INFORMATIONAL)
                 .content(generateNotificationContent(pv))
                 .subject(new PolicyViolationIdentified(pv, pv.getComponent(), pv.getProject()))
@@ -495,5 +495,19 @@ public final class NotificationUtil {
 
     private static String generateNotificationContent(final ViolationAnalysis violationAnalysis) {
         return "An violation analysis decision was made to a policy violation affecting a project";
+    }
+
+    private static String generateNotificationTitle(String messageType, Project project){
+        return messageType + " on Project: " + project.toString();
+    }
+
+    private static String generateNotificationTitle(String messageType, Set<Project> affectedProjects){
+        if (affectedProjects.size() == 1){
+            return messageType + " on Project: " + affectedProjects;
+        }else if (affectedProjects.size() > 1){
+            return messageType + " on multiple Projects";
+        }else {
+            return "";
+        }
     }
 }

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -43,6 +43,7 @@ import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
+import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.net.URLDecoder;
@@ -81,7 +82,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(NotificationGroup.NEW_VULNERABILITY)
-                    .title(generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABILITY, new HashSet<>(affectedProjects.values())))
+                    .title(generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABILITY, component.getProject()))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(detachedVuln))
                     .subject(new NewVulnerabilityIdentified(detachedVuln, detachedComponent, new HashSet<>(affectedProjects.values())))
@@ -148,7 +149,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(notificationGroup)
-                    .title(generateNotificationTitle(title, affectedProjects))
+                    .title(generateNotificationTitle(title, analysis.getComponent().getProject()))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(analysis))
                     .subject(new AnalysisDecisionChange(analysis.getVulnerability(),
@@ -187,7 +188,7 @@ public final class NotificationUtil {
             Notification.dispatch(new Notification()
                     .scope(NotificationScope.PORTFOLIO)
                     .group(notificationGroup)
-                    .title(generateNotificationTitle(title, violationAnalysis.getProject()))
+                    .title(generateNotificationTitle(title, violationAnalysis.getComponent().getProject()))
                     .level(NotificationLevel.INFORMATIONAL)
                     .content(generateNotificationContent(violationAnalysis))
                     .subject(new ViolationAnalysisDecisionChange(violationAnalysis.getPolicyViolation(),
@@ -206,7 +207,7 @@ public final class NotificationUtil {
         Notification.dispatch(new Notification()
                 .scope(NotificationScope.PORTFOLIO)
                 .group(NotificationGroup.POLICY_VIOLATION)
-                .title(generateNotificationTitle(NotificationConstants.Title.POLICY_VIOLATION,policyViolation.getProject()))
+                .title(generateNotificationTitle(NotificationConstants.Title.POLICY_VIOLATION,policyViolation.getComponent().getProject()))
                 .level(NotificationLevel.INFORMATIONAL)
                 .content(generateNotificationContent(pv))
                 .subject(new PolicyViolationIdentified(pv, pv.getComponent(), pv.getProject()))
@@ -497,17 +498,10 @@ public final class NotificationUtil {
         return "An violation analysis decision was made to a policy violation affecting a project";
     }
 
-    private static String generateNotificationTitle(String messageType, Project project){
-        return messageType + " on Project: " + project.toString();
-    }
-
-    private static String generateNotificationTitle(String messageType, Set<Project> affectedProjects){
-        if (affectedProjects.size() == 1){
-            return messageType + " on Project: " + affectedProjects;
-        }else if (affectedProjects.size() > 1){
-            return messageType + " on multiple Projects";
-        }else {
-            return "";
+    public static String generateNotificationTitle(String messageType, Project project) {
+        if (project != null) {
+            return messageType + " on Project: [" + project.toString() + "]";
         }
+        return messageType;
     }
 }

--- a/src/main/resources/templates/notification/publisher/email.peb
+++ b/src/main/resources/templates/notification/publisher/email.peb
@@ -8,6 +8,11 @@ Severity:          {{ subject.vulnerability.severity }}
 Source:            {{ subject.vulnerability.source }}
 Component:         {{ subject.component.toString }}
 Component URL:     {{ baseUrl }}/component/?uuid={{ subject.component.uuid }}
+Affected Projects:
+{% for affectedProject in notification.subject.affectedProjects %}
+Project:           [{{ affectedProject.name }} : {{ affectedProject.version }}]
+Project URL:       {{ baseUrl }}/project/?uuid={{ affectedProject.uuid }}
+{% endfor %}
 {% elseif notification.group == "NEW_VULNERABLE_DEPENDENCY" %}
 Project:           {{ subject.dependency.project.toString }}
 Project URL:       {{ baseUrl }}/project/?uuid={{ subject.dependency.project.uuid }}
@@ -34,8 +39,11 @@ Severity:          {{ subject.vulnerability.severity }}
 Source:            {{ subject.vulnerability.source }}
 Component:         {{ subject.component.toString }}
 Component URL:     {{ baseUrl }}/component/?uuid={{ subject.component.uuid }}
-Project:           {{ subject.project.toString }}
-Project URL:       {{ baseUrl }}/project/?uuid={{ subject.project.uuid }}
+Affected Projects:
+{% for affectedProject in notification.subject.affectedProjects %}
+Project:            [{{ affectedProject.name }} : {{ affectedProject.version }}]
+Project URL:        {{ baseUrl }}/project/?uuid={{ affectedProject.uuid }}
+    {% endfor %}
 {% elseif notification.group == "BOM_CONSUMED" %}
 Project:           {{ subject.project.name }}
 Version:           {{ subject.project.version }}

--- a/src/main/resources/templates/notification/publisher/email.peb
+++ b/src/main/resources/templates/notification/publisher/email.peb
@@ -8,12 +8,18 @@ Severity:          {{ subject.vulnerability.severity }}
 Source:            {{ subject.vulnerability.source }}
 Component:         {{ subject.component.toString }}
 Component URL:     {{ baseUrl }}/component/?uuid={{ subject.component.uuid }}
-Affected Projects:
-{% for affectedProject in notification.subject.affectedProjects %}
+Project:           {{ subject.component.project.name }}
+Version:           {{ subject.component.project.version }}
+Description:       {{ subject.component.project.description }}
+Project URL:       {{ baseUrl }}/projects/{{ subject.component.project.uuid }}
+{% if  notification.subject.affectedProjects|length > 1%}
+--------------------------------------------------------------------------------
+
+Other affected projects:
+{% for affectedProject in notification.subject.affectedProjects %}{% if not (affectedProject.uuid == subject.component.project.uuid) %}
 Project:           [{{ affectedProject.name }} : {{ affectedProject.version }}]
 Project URL:       {{ baseUrl }}/project/?uuid={{ affectedProject.uuid }}
-{% endfor %}
-{% elseif notification.group == "NEW_VULNERABLE_DEPENDENCY" %}
+{% endif %}{% endfor %}{% endif %}{% elseif notification.group == "NEW_VULNERABLE_DEPENDENCY" %}
 Project:           {{ subject.dependency.project.toString }}
 Project URL:       {{ baseUrl }}/project/?uuid={{ subject.dependency.project.uuid }}
 Component:         {{ subject.dependency.component.toString }}
@@ -39,12 +45,18 @@ Severity:          {{ subject.vulnerability.severity }}
 Source:            {{ subject.vulnerability.source }}
 Component:         {{ subject.component.toString }}
 Component URL:     {{ baseUrl }}/component/?uuid={{ subject.component.uuid }}
-Affected Projects:
-{% for affectedProject in notification.subject.affectedProjects %}
-Project:            [{{ affectedProject.name }} : {{ affectedProject.version }}]
-Project URL:        {{ baseUrl }}/project/?uuid={{ affectedProject.uuid }}
-    {% endfor %}
-{% elseif notification.group == "BOM_CONSUMED" %}
+Project:           {{ subject.component.project.name }}
+Version:           {{ subject.component.project.version }}
+Description:       {{ subject.component.project.description }}
+Project URL:       {{ baseUrl }}/projects/{{ subject.component.project.uuid }}
+{% if  notification.subject.affectedProjects|length > 1%}
+--------------------------------------------------------------------------------
+
+Other affected projects:
+{% for affectedProject in notification.subject.affectedProjects %}{% if not (affectedProject.uuid == subject.component.project.uuid) %}
+Project:           [{{ affectedProject.name }} : {{ affectedProject.version }}]
+Project URL:       {{ baseUrl }}/project/?uuid={{ affectedProject.uuid }}
+{% endif %}{% endfor %}{% endif %}{% elseif notification.group == "BOM_CONSUMED" %}
 Project:           {{ subject.project.name }}
 Version:           {{ subject.project.version }}
 Description:       {{ subject.project.description }}


### PR DESCRIPTION
Shows the affected project in the subject line of an email notification to make the emails more distinguishable and to make it easier for a user to gather important information like project name and version quickly.

Changes the default email template for the notification groups `NEW_VULNERABILITY_IDENTIFIED` and `PROJECT_AUDIT_CHANGE` to list the project of the affected component and to list other projects, if these are also affected.

Signed-off-by: RBickert <rbt@mm-software.com>