### PR TITLE
Decode escaped whitespace in file path returned by `.getResource()`

### DIFF
--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -115,7 +115,7 @@ public class BomResourceTest extends ResourceTest {
     public void uploadBomTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").getFile());
+        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, false, bomString);
         Response response = target(V1_BOM).request()
@@ -131,7 +131,7 @@ public class BomResourceTest extends ResourceTest {
     @Test
     public void uploadBomInvalidProjectTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").getFile());
+        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         BomSubmitRequest request = new BomSubmitRequest(UUID.randomUUID().toString(), null, null, false, bomString);
         Response response = target(V1_BOM).request()
@@ -146,7 +146,7 @@ public class BomResourceTest extends ResourceTest {
     @Test
     public void uploadBomAutoCreateTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").getFile());
+        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", true, bomString);
         Response response = target(V1_BOM).request()
@@ -163,7 +163,7 @@ public class BomResourceTest extends ResourceTest {
 
     @Test
     public void uploadBomUnauthorizedTest() throws Exception {
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").getFile());
+        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", true, bomString);
         Response response = target(V1_BOM).request()

--- a/src/test/java/org/dependencytrack/resources/v1/misc/BadgerTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/misc/BadgerTest.java
@@ -31,14 +31,14 @@ import java.nio.charset.StandardCharsets;
 public class BadgerTest {
 
     @Test
-    public void generateVulnerabilitiesWithoutMetricsGenerateExpectedSvg() {
+    public void generateVulnerabilitiesWithoutMetricsGenerateExpectedSvg() throws Exception {
         Badger badger = new Badger();
         String svg = badger.generateVulnerabilities(null);
         Assert.assertEquals(strip(svg), strip(expectedSvg("project-vulns-nometrics.svg")));
     }
 
     @Test
-    public void generateVulnerabilitiesWithoutVulnerabilitiesGenerateExpectedSvg() {
+    public void generateVulnerabilitiesWithoutVulnerabilitiesGenerateExpectedSvg() throws Exception {
         ProjectMetrics metrics = new ProjectMetrics();
         metrics.setVulnerabilities(0);
         Badger badger = new Badger();
@@ -47,7 +47,7 @@ public class BadgerTest {
     }
 
     @Test
-    public void generateVulnerabilitiesWithVulnerabilitiesGenerateExpectedSvg() {
+    public void generateVulnerabilitiesWithVulnerabilitiesGenerateExpectedSvg() throws Exception {
         ProjectMetrics metrics = new ProjectMetrics();
         metrics.setVulnerabilities(1 + 2 + 3 + 4 + 5);
         metrics.setCritical(1);
@@ -61,14 +61,14 @@ public class BadgerTest {
     }
 
     @Test
-    public void generateViolationsWithoutMetricsGenerateExpectedSvg() {
+    public void generateViolationsWithoutMetricsGenerateExpectedSvg() throws Exception {
         Badger badger = new Badger();
         String svg = badger.generateViolations(null);
         Assert.assertEquals(strip(svg), strip(expectedSvg("project-violations-nometrics.svg")));
     }
 
     @Test
-    public void generateViolationsWithoutViolationsGenerateExpectedSvg() {
+    public void generateViolationsWithoutViolationsGenerateExpectedSvg() throws Exception {
         ProjectMetrics metrics = new ProjectMetrics();
         metrics.setPolicyViolationsTotal(0);
         Badger badger = new Badger();
@@ -77,7 +77,7 @@ public class BadgerTest {
     }
 
     @Test
-    public void generateViolationsWithViolationsGenerateExpectedSvg() {
+    public void generateViolationsWithViolationsGenerateExpectedSvg() throws Exception {
         ProjectMetrics metrics = new ProjectMetrics();
         metrics.setPolicyViolationsTotal(1 + 2 + 3);
         metrics.setPolicyViolationsFail(1);
@@ -88,14 +88,14 @@ public class BadgerTest {
         Assert.assertEquals(strip(svg), strip(expectedSvg("project-violations.svg")));
     }
 
-    private String expectedSvg(String filename) {
+    private String expectedSvg(String filename) throws Exception {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         URL resource = contextClassLoader.getResource("badge/" + filename);
         if (resource == null) {
             throw new RuntimeException("can't find expected svg filename=" + filename);
         }
         try {
-            return FileUtils.readFileToString(new File(resource.getFile()), StandardCharsets.UTF_8);
+            return FileUtils.readFileToString(new File(resource.toURI()), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException("can't load expected svg filename=" + filename);
         }

--- a/src/test/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/repositories/ComposerMetaAnalyzerTest.java
@@ -96,7 +96,7 @@ public class ComposerMetaAnalyzerTest {
         );
     }
 
-    private static File getResourceFile(String namespace, String name) {
+    private static File getResourceFile(String namespace, String name) throws Exception{
         return new File(
                 Thread.currentThread().getContextClassLoader()
                         .getResource(String.format(
@@ -104,7 +104,7 @@ public class ComposerMetaAnalyzerTest {
                                 namespace,
                                 name
                         ))
-                        .getFile()
+                        .toURI()
         );
     }
 

--- a/src/test/java/org/dependencytrack/util/HashUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/HashUtilTest.java
@@ -27,25 +27,25 @@ public class HashUtilTest {
 
     @Test
     public void testMd5() throws Exception {
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").getFile());
+        File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").toURI());
         Assert.assertEquals("6ccb8fac358fea58732ed8ffec85b9f5", HashUtil.md5(file));
     }
 
     @Test
     public void testSha1() throws Exception {
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").getFile());
+        File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").toURI());
         Assert.assertEquals("3f4b24f2a4da21774622417444436b193fe34764", HashUtil.sha1(file));
     }
 
     @Test
     public void testSha256() throws Exception {
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").getFile());
+        File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").toURI());
         Assert.assertEquals("958bf829329b84baef5136d99156f6703d0d95cffa9fc6cec6403ced7573eff3", HashUtil.sha256(file));
     }
 
     @Test
     public void testSha512() throws Exception {
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").getFile());
+        File file = new File(Thread.currentThread().getContextClassLoader().getResource("textfile.txt").toURI());
         Assert.assertEquals("1e140d6171bf6377a749d7579034cf4879548d96e9d5299f02a5265e094168fd9812fda94fa5fa9ff45ac8454f19d18f612cb3204ad551e29baddbfa17636b59", HashUtil.sha512(file));
     }
 }


### PR DESCRIPTION
Tests which use `.getResource().getFile` fail if the file path contains any whitespace because the escaped whitespace is not decoded in the returned URL, resulting in failed tests.

Converts the returned URL from `.getResource()` to a URI to decode escaped whitespace, and by that enables whitespace in a file path to pass existing tests.

Signed-off-by: RBickert <rbt@mm-software.com>