### PR TITLE
Allow teams as recipients for email alerts

### DIFF
--- a/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.model;
 
 import alpine.common.validation.RegexSequence;
+import alpine.model.Team;
 import alpine.notification.NotificationLevel;
 import alpine.server.json.TrimmedStringDeserializer;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -99,6 +100,12 @@ public class NotificationRule implements Serializable {
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC, version ASC"))
     private List<Project> projects;
 
+    @Persistent(table = "NOTIFICATIONRULE_TEAMS", defaultFetchGroup = "true")
+    @Join(column = "NOTIFICATIONRULE_ID")
+    @Element(column = "TEAM_ID")
+    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
+    private List<Team> teams;
+
     @Persistent
     @Column(name = "NOTIFY_ON", length = 1024)
     private String notifyOn;
@@ -173,6 +180,14 @@ public class NotificationRule implements Serializable {
 
     public void setProjects(List<Project> projects) {
         this.projects = projects;
+    }
+
+    public List<Team> getTeams() {
+        return teams;
+    }
+
+    public void setTeams(List<Team> teams) {
+        this.teams = teams;
     }
 
     public String getMessage() {

--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -76,15 +76,12 @@ public class NotificationRouter implements Subscriber {
                                                                  .add(Publisher.CONFIG_TEMPLATE_KEY, notificationPublisher.getTemplate())
                                                                  .addAll(Json.createObjectBuilder(config))
                                                                          .build();
-                    if (publisherClass == SendMailPublisher.class) {
-                        if (rule.getTeams().isEmpty() || rule.getTeams() == null){
-                            publisher.inform(restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig);
-                        }else {
-                            ((SendMailPublisher)publisher).inform(restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig, rule.getTeams());
-                        }
-                    }else {
-                      publisher.inform(restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig);
+                    if (publisherClass != SendMailPublisher.class || rule.getTeams().isEmpty() || rule.getTeams() == null){
+                        publisher.inform(restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig);
+                    } else {
+                        ((SendMailPublisher)publisher).inform(restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig, rule.getTeams());
                     }
+
 
                 } else {
                     LOGGER.error("The defined notification publisher is not assignable from " + Publisher.class.getCanonicalName());

--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -27,6 +27,7 @@ import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.notification.publisher.Publisher;
+import org.dependencytrack.notification.publisher.SendMailPublisher;
 import org.dependencytrack.notification.vo.AnalysisDecisionChange;
 import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
 import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
@@ -75,7 +76,16 @@ public class NotificationRouter implements Subscriber {
                                                                  .add(Publisher.CONFIG_TEMPLATE_KEY, notificationPublisher.getTemplate())
                                                                  .addAll(Json.createObjectBuilder(config))
                                                                          .build();
-                    publisher.inform(restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig);
+                    if (publisherClass == SendMailPublisher.class) {
+                        if (rule.getTeams().isEmpty() || rule.getTeams() == null){
+                            publisher.inform(restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig);
+                        }else {
+                            ((SendMailPublisher)publisher).inform(restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig, rule.getTeams());
+                        }
+                    }else {
+                      publisher.inform(restrictNotificationToRuleProjects(notification, rule), notificationPublisherConfig);
+                    }
+
                 } else {
                     LOGGER.error("The defined notification publisher is not assignable from " + Publisher.class.getCanonicalName());
                 }
@@ -145,7 +155,7 @@ public class NotificationRouter implements Subscriber {
             sb.append("enabled == true && scope == :scope"); //todo: improve this - this only works for testing
             query.setFilter(sb.toString());
             final List<NotificationRule> result = (List<NotificationRule>)query.execute(NotificationScope.valueOf(notification.getScope()));
-
+            pm.detachCopyAll(result);
 
             if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() != null && notification.getSubject() instanceof NewVulnerabilityIdentified) {

--- a/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.persistence;
 
+import alpine.model.Team;
 import alpine.notification.NotificationLevel;
 import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
@@ -200,6 +201,18 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
         final Query<NotificationRule> query = pm.newQuery(NotificationRule.class, "projects.contains(:project)");
         for (final NotificationRule rule: (List<NotificationRule>) query.execute(project)) {
             rule.getProjects().remove(project);
+            persist(rule);
+        }
+    }
+
+    /**
+     * Removes teams from NotificationRules
+     */
+    @SuppressWarnings("unchecked")
+    public void removeTeamFromNotificationRules(final Team team) {
+        final Query<NotificationRule> query = pm.newQuery(NotificationRule.class, "teams.contains(:team)");
+        for (final NotificationRule rule: (List<NotificationRule>) query.execute(team)) {
+            rule.getTeams().remove(team);
             persist(rule);
         }
     }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1052,6 +1052,10 @@ public class QueryManager extends AlpineQueryManager {
         getNotificationQueryManager().removeProjectFromNotificationRules(project);
     }
 
+    public void removeTeamFromNotificationRules(final Team team) {
+        getNotificationQueryManager().removeTeamFromNotificationRules(team);
+    }
+
     /**
      * Determines if a config property is enabled or not.
      * @param configPropertyConstants the property to query

--- a/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.common.logging.Logger;
+import alpine.model.Team;
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
 import alpine.server.resources.AlpineResource;
@@ -35,6 +36,7 @@ import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.notification.NotificationScope;
+import org.dependencytrack.notification.publisher.DefaultNotificationPublishers;
 import org.dependencytrack.persistence.QueryManager;
 
 import javax.validation.Validator;
@@ -249,6 +251,94 @@ public class NotificationRuleResource extends AlpineResource {
             final List<Project> projects = rule.getProjects();
             if (projects != null && projects.contains(project)) {
                 rule.getProjects().remove(project);
+                qm.persist(rule);
+                return Response.ok(rule).build();
+            }
+            return Response.status(Response.Status.NOT_MODIFIED).build();
+        }
+    }
+
+    @POST
+    @Path("/{ruleUuid}/team/{teamUuid}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Adds a team to a notification rule",
+            response = NotificationRule.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 304, message = "The rule already has the specified team assigned"),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 404, message = "The notification rule or team could not be found")
+    })
+    @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
+    public Response addTeamToRule(
+            @ApiParam(value = "The UUID of the rule to add a team to", required = true)
+            @PathParam("ruleUuid") String ruleUuid,
+            @ApiParam(value = "The UUID of the team to add to the rule", required = true)
+            @PathParam("teamUuid") String teamUuid) {
+        try (QueryManager qm = new QueryManager()) {
+            final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
+            if (rule == null) {
+                return Response.status(Response.Status.NOT_FOUND).entity("The notification rule could not be found.").build();
+            }
+            if (rule.getScope() != NotificationScope.PORTFOLIO) {
+                return Response.status(Response.Status.NOT_ACCEPTABLE).entity("Team subscriptions are only possible on notification rules with PORTFOLIO scope.").build();
+            }
+            if (!rule.getPublisher().getName().equals(DefaultNotificationPublishers.EMAIL.getPublisherName())) {
+                return Response.status(Response.Status.NOT_ACCEPTABLE).entity("Team subscriptions are only possible on notification rules with EMAIL publisher.").build();
+            }
+            final Team team = qm.getObjectByUuid(Team.class, teamUuid);
+            if (team == null) {
+                return Response.status(Response.Status.NOT_FOUND).entity("The team could not be found.").build();
+            }
+            final List<Team> teams = rule.getTeams();
+            if (teams != null && !teams.contains(team)) {
+                rule.getTeams().add(team);
+                qm.persist(rule);
+                return Response.ok(rule).build();
+            }
+            return Response.status(Response.Status.NOT_MODIFIED).build();
+        }
+    }
+
+    @DELETE
+    @Path("/{ruleUuid}/team/{teamUuid}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Removes a team from a notification rule",
+            response = NotificationRule.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 304, message = "The rule does not have the specified team assigned"),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 404, message = "The notification rule or team could not be found")
+    })
+    @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
+    public Response removeTeamFromRule(
+            @ApiParam(value = "The UUID of the rule to remove the project from", required = true)
+            @PathParam("ruleUuid") String ruleUuid,
+            @ApiParam(value = "The UUID of the project to remove from the rule", required = true)
+            @PathParam("teamUuid") String teamUuid) {
+        try (QueryManager qm = new QueryManager()) {
+            final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
+            if (rule == null) {
+                return Response.status(Response.Status.NOT_FOUND).entity("The notification rule could not be found.").build();
+            }
+            if (rule.getScope() != NotificationScope.PORTFOLIO) {
+                return Response.status(Response.Status.NOT_ACCEPTABLE).entity("Team subscriptions are only possible on notification rules with PORTFOLIO scope.").build();
+            }
+            if (!rule.getPublisher().getName().equals(DefaultNotificationPublishers.EMAIL.getPublisherName())) {
+                return Response.status(Response.Status.NOT_ACCEPTABLE).entity("Team subscriptions are only possible on notification rules with EMAIL publisher.").build();
+            }
+            final Team team = qm.getObjectByUuid(Team.class, teamUuid);
+            if (team == null) {
+                return Response.status(Response.Status.NOT_FOUND).entity("The team could not be found.").build();
+            }
+            final List<Team> teams = rule.getTeams();
+            if (teams != null && teams.contains(team)) {
+                rule.getTeams().remove(team);
                 qm.persist(rule);
                 return Response.ok(rule).build();
             }

--- a/src/test/java/org/dependencytrack/model/NotificationRuleTest.java
+++ b/src/test/java/org/dependencytrack/model/NotificationRuleTest.java
@@ -18,6 +18,10 @@
  */
 package org.dependencytrack.model;
 
+import alpine.model.LdapUser;
+import alpine.model.ManagedUser;
+import alpine.model.OidcUser;
+import alpine.model.Team;
 import alpine.notification.NotificationLevel;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
@@ -30,42 +34,42 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-public class NotificationRuleTest { 
+public class NotificationRuleTest {
 
     @Test
     public void testId() {
         NotificationRule rule = new NotificationRule();
         rule.setId(111L);
         Assert.assertEquals(111L, rule.getId());
-    } 
+    }
 
     @Test
     public void testName() {
         NotificationRule rule = new NotificationRule();
         rule.setName("Test Name");
         Assert.assertEquals("Test Name", rule.getName());
-    } 
+    }
 
     @Test
     public void testEnabled() {
         NotificationRule rule = new NotificationRule();
         rule.setEnabled(true);
         Assert.assertTrue(rule.isEnabled());
-    } 
+    }
 
     @Test
     public void testScope() {
         NotificationRule rule = new NotificationRule();
         rule.setScope(NotificationScope.PORTFOLIO);
         Assert.assertEquals(NotificationScope.PORTFOLIO, rule.getScope());
-    } 
+    }
 
     @Test
     public void testNotificationLevel() {
         NotificationRule rule = new NotificationRule();
         rule.setNotificationLevel(NotificationLevel.INFORMATIONAL);
         Assert.assertEquals(NotificationLevel.INFORMATIONAL, rule.getNotificationLevel());
-    } 
+    }
 
     @Test
     public void testProjects() {
@@ -76,14 +80,14 @@ public class NotificationRuleTest {
         rule.setProjects(projects);
         Assert.assertEquals(1, rule.getProjects().size());
         Assert.assertEquals(project, rule.getProjects().get(0));
-    } 
+    }
 
     @Test
     public void testMessage() {
         NotificationRule rule = new NotificationRule();
         rule.setMessage("Test Message");
         Assert.assertEquals("Test Message", rule.getMessage());
-    } 
+    }
 
     @Test
     public void testNotifyOn() {
@@ -93,7 +97,7 @@ public class NotificationRuleTest {
         NotificationRule rule = new NotificationRule();
         rule.setNotifyOn(groups);
         Assert.assertEquals(2, rule.getNotifyOn().size());
-    } 
+    }
 
     @Test
     public void testPublisher() {
@@ -101,14 +105,14 @@ public class NotificationRuleTest {
         NotificationRule rule = new NotificationRule();
         rule.setPublisher(publisher);
         Assert.assertEquals(publisher, rule.getPublisher());
-    } 
+    }
 
     @Test
     public void testPublisherConfig() {
         NotificationRule rule = new NotificationRule();
         rule.setPublisherConfig("{ \"config\": \"configured\" }");
         Assert.assertEquals("{ \"config\": \"configured\" }", rule.getPublisherConfig());
-    } 
+    }
 
     @Test
     public void testUuid() {
@@ -116,5 +120,64 @@ public class NotificationRuleTest {
         NotificationRule rule = new NotificationRule();
         rule.setUuid(uuid);
         Assert.assertEquals(uuid.toString(), rule.getUuid().toString());
-    } 
+    }
+
+    @Test
+    public void testTeams(){
+        List<Team> teams = new ArrayList<>();
+        Team team = new Team();
+        teams.add(team);
+        NotificationRule rule = new NotificationRule();
+        rule.setTeams(teams);
+        Assert.assertEquals(1, rule.getTeams().size());
+        Assert.assertEquals(team, rule.getTeams().get(0));
+    }
+
+    @Test
+    public void testManagedUsers(){
+        List<Team> teams = new ArrayList<>();
+        Team team = new Team();
+        List<ManagedUser> managedUsers = new ArrayList<>();
+        ManagedUser managedUser = new ManagedUser();
+        managedUsers.add(managedUser);
+        team.setManagedUsers(managedUsers);
+        teams.add(team);
+        NotificationRule rule = new NotificationRule();
+        rule.setTeams(teams);
+        Assert.assertEquals(1, rule.getTeams().size());
+        Assert.assertEquals(team, rule.getTeams().get(0));
+        Assert.assertEquals(managedUser, rule.getTeams().get(0).getManagedUsers().get(0));
+    }
+
+    @Test
+    public void testLdapUsers(){
+        List<Team> teams = new ArrayList<>();
+        Team team = new Team();
+        List<LdapUser> ldapUsers = new ArrayList<>();
+        LdapUser ldapUser = new LdapUser();
+        ldapUsers.add(ldapUser);
+        team.setLdapUsers(ldapUsers);
+        teams.add(team);
+        NotificationRule rule = new NotificationRule();
+        rule.setTeams(teams);
+        Assert.assertEquals(1, rule.getTeams().size());
+        Assert.assertEquals(team, rule.getTeams().get(0));
+        Assert.assertEquals(ldapUser, rule.getTeams().get(0).getLdapUsers().get(0));
+    }
+
+    @Test
+    public void testOidcUsers(){
+        List<Team> teams = new ArrayList<>();
+        Team team = new Team();
+        List<OidcUser> oidcUsers = new ArrayList<>();
+        OidcUser oidcUser = new OidcUser();
+        oidcUsers.add(oidcUser);
+        team.setOidcUsers(oidcUsers);
+        teams.add(team);
+        NotificationRule rule = new NotificationRule();
+        rule.setTeams(teams);
+        Assert.assertEquals(1, rule.getTeams().size());
+        Assert.assertEquals(team, rule.getTeams().get(0));
+        Assert.assertEquals(oidcUser, rule.getTeams().get(0).getOidcUsers().get(0));
+    }
 }

--- a/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
@@ -223,11 +223,20 @@ public class SendMailPublisherTest {
   public void testEmptyTeamAsDestination(){
     JsonObject config = configWithDestination("");
     List<Team> teams = new ArrayList<>();
+    Team team = new Team();
+    teams.add(team);
     Assert.assertArrayEquals(null, SendMailPublisher.parseDestination(config, teams));
   }
 
   @Test
-  public void testEmptyUsersAsDestination(){
+  public void testEmptyTeamsAsDestination(){
+    JsonObject config = configWithDestination("");
+    List<Team> teams = new ArrayList<>();
+    Assert.assertArrayEquals(null, SendMailPublisher.parseDestination(config, teams));
+  }
+
+  @Test
+  public void testEmptyUserEmailsAsDestination(){
     JsonObject config = configWithDestination("");
     ManagedUser managedUser = new ManagedUser();
     managedUser.setUsername("ManagedUserTest");
@@ -279,6 +288,78 @@ public class SendMailPublisherTest {
     team.setManagedUsers(managedUsers);
     team.setLdapUsers(ldapUsers);
     team.setOidcUsers(oidcUsers);
+    teams.add(team);
+
+    Assert.assertArrayEquals(new String[] {"john@doe.com", "steve@jobs.org", "managedUser@Test.com", "ldapUser@Test.com"}, SendMailPublisher.parseDestination(config, teams));
+  }
+
+  @Test
+  public void testEmptyManagedUsersAsDestination(){
+    JsonObject config = configWithDestination("john@doe.com,steve@jobs.org");
+
+    LdapUser ldapUser = new LdapUser();
+    ldapUser.setUsername("ldapUserTest");
+    ldapUser.setEmail("ldapUser@Test.com");
+    List<LdapUser> ldapUsers = new ArrayList<>();
+    ldapUsers.add(ldapUser);
+
+    OidcUser oidcUser = new OidcUser();
+    oidcUser.setUsername("oidcUserTest");
+    oidcUser.setEmail("oidcUser@Test.com");
+    List<OidcUser> oidcUsers = new ArrayList<>();
+    oidcUsers.add(oidcUser);
+
+    List<Team> teams = new ArrayList<>();
+    Team team = new Team();
+    team.setLdapUsers(ldapUsers);
+    team.setOidcUsers(oidcUsers);
+    teams.add(team);
+
+    Assert.assertArrayEquals(new String[] {"john@doe.com", "steve@jobs.org", "ldapUser@Test.com", "oidcUser@Test.com"}, SendMailPublisher.parseDestination(config, teams));
+  }
+
+  @Test
+  public void testEmptyLdapUsersAsDestination(){
+    JsonObject config = configWithDestination("john@doe.com,steve@jobs.org");
+    ManagedUser managedUser = new ManagedUser();
+    managedUser.setUsername("ManagedUserTest");
+    managedUser.setEmail("managedUser@Test.com");
+    List<ManagedUser> managedUsers = new ArrayList<>();
+    managedUsers.add(managedUser);
+
+    OidcUser oidcUser = new OidcUser();
+    oidcUser.setUsername("oidcUserTest");
+    oidcUser.setEmail("oidcUser@Test.com");
+    List<OidcUser> oidcUsers = new ArrayList<>();
+    oidcUsers.add(oidcUser);
+
+    List<Team> teams = new ArrayList<>();
+    Team team = new Team();
+    team.setManagedUsers(managedUsers);
+    team.setOidcUsers(oidcUsers);
+    teams.add(team);
+
+    Assert.assertArrayEquals(new String[] {"john@doe.com", "steve@jobs.org", "managedUser@Test.com", "oidcUser@Test.com"}, SendMailPublisher.parseDestination(config, teams));
+  }
+  @Test
+  public void testEmptyOidcUsersAsDestination(){
+    JsonObject config = configWithDestination("john@doe.com,steve@jobs.org");
+    ManagedUser managedUser = new ManagedUser();
+    managedUser.setUsername("ManagedUserTest");
+    managedUser.setEmail("managedUser@Test.com");
+    List<ManagedUser> managedUsers = new ArrayList<>();
+    managedUsers.add(managedUser);
+
+    LdapUser ldapUser = new LdapUser();
+    ldapUser.setUsername("ldapUserTest");
+    ldapUser.setEmail("ldapUser@Test.com");
+    List<LdapUser> ldapUsers = new ArrayList<>();
+    ldapUsers.add(ldapUser);
+
+    List<Team> teams = new ArrayList<>();
+    Team team = new Team();
+    team.setManagedUsers(managedUsers);
+    team.setLdapUsers(ldapUsers);
     teams.add(team);
 
     Assert.assertArrayEquals(new String[] {"john@doe.com", "steve@jobs.org", "managedUser@Test.com", "ldapUser@Test.com"}, SendMailPublisher.parseDestination(config, teams));

--- a/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
+++ b/src/test/java/org/dependencytrack/notification/publisher/SendMailPublisherTest.java
@@ -1,10 +1,16 @@
 package org.dependencytrack.notification.publisher;
 
+import alpine.model.LdapUser;
+import alpine.model.ManagedUser;
+import alpine.model.OidcUser;
+import alpine.model.Team;
 import org.junit.Assert;
 import org.junit.Test;
 
 import javax.json.Json;
 import javax.json.JsonObject;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SendMailPublisherTest {
   private static JsonObject configWithDestination(final String destination) {
@@ -33,4 +39,248 @@ public class SendMailPublisherTest {
     Assert.assertArrayEquals(null, SendMailPublisher.parseDestination(config));
   }
 
+  @Test
+  public void testSingleTeamAsDestination(){
+    JsonObject config = configWithDestination("");
+
+    ManagedUser managedUser = new ManagedUser();
+    managedUser.setUsername("ManagedUserTest");
+    managedUser.setEmail("managedUser@Test.com");
+    List<ManagedUser> managedUsers = new ArrayList<>();
+    managedUsers.add(managedUser);
+
+    LdapUser ldapUser = new LdapUser();
+    ldapUser.setUsername("ldapUserTest");
+    ldapUser.setEmail("ldapUser@Test.com");
+    List<LdapUser> ldapUsers = new ArrayList<>();
+    ldapUsers.add(ldapUser);
+
+    OidcUser oidcUser = new OidcUser();
+    oidcUser.setUsername("oidcUserTest");
+    oidcUser.setEmail("oidcUser@Test.com");
+    List<OidcUser> oidcUsers = new ArrayList<>();
+    oidcUsers.add(oidcUser);
+
+    List<Team> teams = new ArrayList<>();
+    Team team = new Team();
+    team.setManagedUsers(managedUsers);
+    team.setLdapUsers(ldapUsers);
+    team.setOidcUsers(oidcUsers);
+    teams.add(team);
+
+    Assert.assertArrayEquals(new String[] {"managedUser@Test.com", "ldapUser@Test.com", "oidcUser@Test.com"}, SendMailPublisher.parseDestination(config, teams));
+  }
+
+  @Test
+  public void testMultipleTeamsAsDestination(){
+    JsonObject config = configWithDestination("");
+
+    ManagedUser managedUser1 = new ManagedUser();
+    managedUser1.setUsername("ManagedUserTest");
+    managedUser1.setEmail("managedUser@Test.com");
+    List<ManagedUser> managedUsers1 = new ArrayList<>();
+    managedUsers1.add(managedUser1);
+
+    LdapUser ldapUser1 = new LdapUser();
+    ldapUser1.setUsername("ldapUserTest");
+    ldapUser1.setEmail("ldapUser@Test.com");
+    List<LdapUser> ldapUsers1 = new ArrayList<>();
+    ldapUsers1.add(ldapUser1);
+
+    OidcUser oidcUser1 = new OidcUser();
+    oidcUser1.setUsername("oidcUserTest");
+    oidcUser1.setEmail("oidcUser@Test.com");
+    List<OidcUser> oidcUsers1 = new ArrayList<>();
+    oidcUsers1.add(oidcUser1);
+
+    List<Team> teams = new ArrayList<>();
+    Team team1 = new Team();
+    team1.setManagedUsers(managedUsers1);
+    team1.setLdapUsers(ldapUsers1);
+    team1.setOidcUsers(oidcUsers1);
+    teams.add(team1);
+
+    ManagedUser managedUser2 = new ManagedUser();
+    managedUser2.setUsername("ManagedUserTest");
+    managedUser2.setEmail("anotherManagedUser@Test.com");
+    List<ManagedUser> managedUsers2 = new ArrayList<>();
+    managedUsers2.add(managedUser2);
+
+    LdapUser ldapUser2 = new LdapUser();
+    ldapUser2.setUsername("ldapUserTest");
+    ldapUser2.setEmail("anotherLdapUser@Test.com");
+    List<LdapUser> ldapUsers2 = new ArrayList<>();
+    ldapUsers2.add(ldapUser2);
+
+    OidcUser oidcUser2 = new OidcUser();
+    oidcUser2.setUsername("oidcUserTest");
+    oidcUser2.setEmail("anotherOidcUser@Test.com");
+    List<OidcUser> oidcUsers2 = new ArrayList<>();
+    oidcUsers2.add(oidcUser2);
+
+    Team team2 = new Team();
+    team2.setManagedUsers(managedUsers2);
+    team2.setLdapUsers(ldapUsers2);
+    team2.setOidcUsers(oidcUsers2);
+    teams.add(team2);
+
+    Assert.assertArrayEquals(new String[] {"managedUser@Test.com", "ldapUser@Test.com", "oidcUser@Test.com", "anotherManagedUser@Test.com",
+            "anotherLdapUser@Test.com", "anotherOidcUser@Test.com"}, SendMailPublisher.parseDestination(config, teams));
+  }
+
+  @Test
+  public void testDuplicateTeamAsDestination(){
+    JsonObject config = configWithDestination("");
+
+    ManagedUser managedUser1 = new ManagedUser();
+    managedUser1.setUsername("ManagedUserTest");
+    managedUser1.setEmail("managedUser@Test.com");
+    List<ManagedUser> managedUsers1 = new ArrayList<>();
+    managedUsers1.add(managedUser1);
+
+    LdapUser ldapUser1 = new LdapUser();
+    ldapUser1.setUsername("ldapUserTest");
+    ldapUser1.setEmail("ldapUser@Test.com");
+    List<LdapUser> ldapUsers1 = new ArrayList<>();
+    ldapUsers1.add(ldapUser1);
+
+    OidcUser oidcUser1 = new OidcUser();
+    oidcUser1.setUsername("oidcUserTest");
+    oidcUser1.setEmail("oidcUser@Test.com");
+    List<OidcUser> oidcUsers1 = new ArrayList<>();
+    oidcUsers1.add(oidcUser1);
+
+    List<Team> teams = new ArrayList<>();
+    Team team1 = new Team();
+    team1.setManagedUsers(managedUsers1);
+    team1.setLdapUsers(ldapUsers1);
+    team1.setOidcUsers(oidcUsers1);
+    teams.add(team1);
+
+    ManagedUser managedUser2 = new ManagedUser();
+    managedUser2.setUsername("ManagedUserTest");
+    managedUser2.setEmail("anotherManagedUser@Test.com");
+    List<ManagedUser> managedUsers2 = new ArrayList<>();
+    managedUsers2.add(managedUser2);
+
+    LdapUser ldapUser2 = new LdapUser();
+    ldapUser2.setUsername("ldapUserTest");
+    ldapUser2.setEmail("anotherLdapUser@Test.com");
+    List<LdapUser> ldapUsers2 = new ArrayList<>();
+    ldapUsers2.add(ldapUser2);
+
+    OidcUser oidcUser2 = new OidcUser();
+    oidcUser2.setUsername("oidcUserTest");
+    oidcUser2.setEmail("anotherOidcUser@Test.com");
+    List<OidcUser> oidcUsers2 = new ArrayList<>();
+    oidcUsers2.add(oidcUser2);
+    oidcUsers2.add(oidcUser1);
+
+    Team team2 = new Team();
+    team2.setManagedUsers(managedUsers2);
+    team2.setLdapUsers(ldapUsers2);
+    team2.setOidcUsers(oidcUsers2);
+    teams.add(team2);
+
+    Assert.assertArrayEquals(new String[] {"managedUser@Test.com", "ldapUser@Test.com", "oidcUser@Test.com", "anotherManagedUser@Test.com",
+            "anotherLdapUser@Test.com", "anotherOidcUser@Test.com"}, SendMailPublisher.parseDestination(config, teams));
+  }
+
+  @Test
+  public void testDuplicateUserAsDestination(){
+    JsonObject config = configWithDestination("");
+
+    ManagedUser managedUser = new ManagedUser();
+    managedUser.setUsername("ManagedUserTest");
+    managedUser.setEmail("managedUser@Test.com");
+    List<ManagedUser> managedUsers = new ArrayList<>();
+    managedUsers.add(managedUser);
+
+    LdapUser ldapUser = new LdapUser();
+    ldapUser.setUsername("ldapUserTest");
+    ldapUser.setEmail("ldapUser@Test.com");
+    List<LdapUser> ldapUsers = new ArrayList<>();
+    ldapUsers.add(ldapUser);
+
+    OidcUser oidcUser = new OidcUser();
+    oidcUser.setUsername("oidcUserTest");
+    oidcUser.setEmail("oidcUser@Test.com");
+    List<OidcUser> oidcUsers = new ArrayList<>();
+    oidcUsers.add(oidcUser);
+
+    List<Team> teams = new ArrayList<>();
+    Team team = new Team();
+    team.setManagedUsers(managedUsers);
+    team.setLdapUsers(ldapUsers);
+    team.setOidcUsers(oidcUsers);
+    teams.add(team);
+    teams.add(team);
+
+    Assert.assertArrayEquals(new String[] {"managedUser@Test.com", "ldapUser@Test.com", "oidcUser@Test.com"}, SendMailPublisher.parseDestination(config, teams));
+  }
+
+  @Test
+  public void testEmptyTeamAsDestination(){
+    JsonObject config = configWithDestination("");
+    List<Team> teams = new ArrayList<>();
+    Assert.assertArrayEquals(null, SendMailPublisher.parseDestination(config, teams));
+  }
+
+  @Test
+  public void testEmptyUsersAsDestination(){
+    JsonObject config = configWithDestination("");
+    ManagedUser managedUser = new ManagedUser();
+    managedUser.setUsername("ManagedUserTest");
+    List<ManagedUser> managedUsers = new ArrayList<>();
+    managedUsers.add(managedUser);
+
+    LdapUser ldapUser = new LdapUser();
+    ldapUser.setUsername("ldapUserTest");
+    List<LdapUser> ldapUsers = new ArrayList<>();
+    ldapUsers.add(ldapUser);
+
+    OidcUser oidcUser = new OidcUser();
+    oidcUser.setUsername("oidcUserTest");
+    List<OidcUser> oidcUsers = new ArrayList<>();
+    oidcUsers.add(oidcUser);
+
+    List<Team> teams = new ArrayList<>();
+    Team team = new Team();
+    team.setManagedUsers(managedUsers);
+    team.setLdapUsers(ldapUsers);
+    team.setOidcUsers(oidcUsers);
+    teams.add(team);
+
+    Assert.assertArrayEquals(null, SendMailPublisher.parseDestination(config, teams));
+  }
+  @Test
+  public void testConfigDestinationAndTeamAsDestination(){
+    JsonObject config = configWithDestination("john@doe.com,steve@jobs.org");
+    ManagedUser managedUser = new ManagedUser();
+    managedUser.setUsername("ManagedUserTest");
+    managedUser.setEmail("managedUser@Test.com");
+    List<ManagedUser> managedUsers = new ArrayList<>();
+    managedUsers.add(managedUser);
+
+    LdapUser ldapUser = new LdapUser();
+    ldapUser.setUsername("ldapUserTest");
+    ldapUser.setEmail("ldapUser@Test.com");
+    List<LdapUser> ldapUsers = new ArrayList<>();
+    ldapUsers.add(ldapUser);
+
+    OidcUser oidcUser = new OidcUser();
+    oidcUser.setUsername("oidcUserTest");
+    oidcUser.setEmail("john@doe.com");
+    List<OidcUser> oidcUsers = new ArrayList<>();
+    oidcUsers.add(oidcUser);
+
+    List<Team> teams = new ArrayList<>();
+    Team team = new Team();
+    team.setManagedUsers(managedUsers);
+    team.setLdapUsers(ldapUsers);
+    team.setOidcUsers(oidcUsers);
+    teams.add(team);
+
+    Assert.assertArrayEquals(new String[] {"john@doe.com", "steve@jobs.org", "managedUser@Test.com", "ldapUser@Test.com"}, SendMailPublisher.parseDestination(config, teams));
+  }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.common.util.UuidUtil;
+import alpine.model.Team;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.notification.NotificationLevel;
@@ -326,5 +327,175 @@ public class NotificationRuleResourceTest extends ResourceTest {
                 .delete();
         Assert.assertEquals(304, response.getStatus(), 0);
         Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+    }
+
+    @Test
+    public void addTeamToRuleTest(){
+        Team team = qm.createTeam("Team Example", false);
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
+        NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(""));
+        Assert.assertEquals(200, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals("Example Rule", json.getString("name"));
+        Assert.assertEquals(1, json.getJsonArray("teams").size());
+        Assert.assertEquals("Team Example", json.getJsonArray("teams").getJsonObject(0).getString("name"));
+        Assert.assertEquals(team.getUuid().toString(), json.getJsonArray("teams").getJsonObject(0).getString("uuid"));
+    }
+
+    @Test
+    public void addTeamToRuleInvalidRuleTest(){
+        Team team = qm.createTeam("Team Example", false);
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
+        Response response = target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/team/" + team.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(""));
+        Assert.assertEquals(404, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("The notification rule could not be found.", body);
+    }
+
+    @Test
+    public void addTeamToRuleInvalidScopeTest(){
+        Team team = qm.createTeam("Team Example", false);
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
+        NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.SYSTEM, NotificationLevel.INFORMATIONAL, publisher);
+        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(""));
+        Assert.assertEquals(406, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("Team subscriptions are only possible on notification rules with PORTFOLIO scope.", body);
+    }
+
+    @Test
+    public void addTeamToRuleInvalidTeamTest() {
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
+        NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + UUID.randomUUID().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(""));
+        Assert.assertEquals(404, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("The team could not be found.", body);
+    }
+
+
+    @Test
+    public void addTeamToRuleDuplicateTeamTest() {
+        Team team = qm.createTeam("Team Example", false);
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
+        NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        List<Team> teams = new ArrayList<>();
+        teams.add(team);
+        rule.setTeams(teams);
+        qm.persist(rule);
+        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(""));
+        Assert.assertEquals(304, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+    }
+
+    @Test
+    public void addTeamToRuleInvalidPublisherTest(){
+        Team team = qm.createTeam("Team Example", false);
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
+        NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(""));
+        Assert.assertEquals(406, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("Team subscriptions are only possible on notification rules with EMAIL publisher.", body);
+    }
+
+    @Test
+    public void removeTeamFromRuleTest() {
+        Team team = qm.createTeam("Team Example", false);
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
+        NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        List<Team> teams = new ArrayList<>();
+        teams.add(team);
+        rule.setTeams(teams);
+        qm.persist(rule);
+        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+    }
+
+    @Test
+    public void removeTeamFromRuleInvalidRuleTest() {
+        Team team = qm.createTeam("Team Example", false);
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
+        Response response = target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/team/" + team.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        Assert.assertEquals(404, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("The notification rule could not be found.", body);
+    }
+
+    @Test
+    public void removeTeamFromRuleInvalidScopeTest() {
+        Team team = qm.createTeam("Team Example", false);
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
+        NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.SYSTEM, NotificationLevel.INFORMATIONAL, publisher);
+        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        Assert.assertEquals(406, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("Team subscriptions are only possible on notification rules with PORTFOLIO scope.", body);
+    }
+
+    @Test
+    public void removeTeamFromRuleInvalidTeamTest() {
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
+        NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + UUID.randomUUID().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        Assert.assertEquals(404, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("The team could not be found.", body);
+    }
+
+    @Test
+    public void removeTeamFromRuleDuplicateTeamTest() {
+        Team team = qm.createTeam("Team Example", false);
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
+        NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        Assert.assertEquals(304, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+    }
+
+    @Test
+    public void removeTeamToRuleInvalidPublisherTest(){
+        Team team = qm.createTeam("Team Example", false);
+        NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
+        NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        Assert.assertEquals(406, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("Team subscriptions are only possible on notification rules with EMAIL publisher.", body);
     }
 }


### PR DESCRIPTION
Managing the destination of a notification rule takes a lot of time for a large group of recipients because it needs to be done manually by a user for every single recipient.

Allowing teams to be subscribed to an email alert automates this process, as every user of a subscribed team will automatically get an email without the need of inserting their email address as a destination.  

Not having to manually insert every single email address into the notification rule destination simplifies the management of notification recipients and allows dynamic email destinations by subscribing and reorganizing teams.
Individual persons can still be added as recipients if they are manually put as a destination.

Signed-off-by: RBickert <rbt@mm-software.com>