### PR TITLE
Limit alert rules to project including all existing or future versions

### DIFF
--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -219,20 +219,17 @@ public class NotificationRouter implements Subscriber {
         }
     }
 
-    private boolean checkIfChildrenAreAffected(Project parent, UUID uuid){
+    private boolean checkIfChildrenAreAffected(Project parent, UUID uuid) {
         boolean isChild = false;
-        if (parent.getChildren() == null || parent.getChildren().isEmpty()){
+        if (parent.getChildren() == null || parent.getChildren().isEmpty()) {
             return false;
-        } else {
-            for (Project child : parent.getChildren()){
-                if ((child.getUuid().equals(uuid) && child.isActive()) || isChild){
-                    return true;
-                } else {
-                    isChild = checkIfChildrenAreAffected(child, uuid);
-                }
+        }
+        for (Project child : parent.getChildren()) {
+            if ((child.getUuid().equals(uuid) && child.isActive()) || isChild) {
+                return true;
             }
+            isChild = checkIfChildrenAreAffected(child, uuid);
         }
         return isChild;
     }
-
 }

--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -161,7 +161,7 @@ public class NotificationRouter implements Subscriber {
                         if (rule.getProjects() != null && rule.getProjects().size() > 0
                             && subject.getComponent() != null && subject.getComponent().getProject() != null) {
                             for (final Project project : rule.getProjects()) {
-                                if (subject.getComponent().getProject().getUuid().equals(project.getUuid()) || checkChildren(project, subject.getComponent().getProject().getUuid())) {
+                                if (subject.getComponent().getProject().getUuid().equals(project.getUuid()) || checkIfChildrenAreAffected(project, subject.getComponent().getProject().getUuid())) {
                                     rules.add(rule);
                                 }
                             }
@@ -208,7 +208,7 @@ public class NotificationRouter implements Subscriber {
             if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
                 if (rule.getProjects() != null && rule.getProjects().size() > 0) {
                     for (final Project project : rule.getProjects()) {
-                        if (project.getUuid().equals(limitToProject.getUuid()) || checkChildren(project, limitToProject.getUuid())) {
+                        if (project.getUuid().equals(limitToProject.getUuid()) || checkIfChildrenAreAffected(project, limitToProject.getUuid())) {
                             applicableRules.add(rule);
                         }
                     }
@@ -219,7 +219,7 @@ public class NotificationRouter implements Subscriber {
         }
     }
 
-    private boolean checkChildren(Project parent, UUID uuid){
+    private boolean checkIfChildrenAreAffected(Project parent, UUID uuid){
         boolean isChild = false;
         if (parent.getChildren() == null || parent.getChildren().isEmpty()){
             return false;
@@ -228,7 +228,7 @@ public class NotificationRouter implements Subscriber {
                 if ((child.getUuid().equals(uuid) && child.isActive()) || isChild){
                     return true;
                 } else {
-                    isChild = checkChildren(child, uuid);
+                    isChild = checkIfChildrenAreAffected(child, uuid);
                 }
             }
         }

--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -161,7 +161,7 @@ public class NotificationRouter implements Subscriber {
                         if (rule.getProjects() != null && rule.getProjects().size() > 0
                             && subject.getComponent() != null && subject.getComponent().getProject() != null) {
                             for (final Project project : rule.getProjects()) {
-                                if (subject.getComponent().getProject().getUuid().equals(project.getUuid())) {
+                                if (subject.getComponent().getProject().getUuid().equals(project.getUuid()) || checkChildren(project, subject.getComponent().getProject().getUuid())) {
                                     rules.add(rule);
                                 }
                             }
@@ -208,7 +208,7 @@ public class NotificationRouter implements Subscriber {
             if (rule.getNotifyOn().contains(NotificationGroup.valueOf(notification.getGroup()))) {
                 if (rule.getProjects() != null && rule.getProjects().size() > 0) {
                     for (final Project project : rule.getProjects()) {
-                        if (project.getUuid().equals(limitToProject.getUuid())) {
+                        if (project.getUuid().equals(limitToProject.getUuid()) || checkChildren(project, limitToProject.getUuid())) {
                             applicableRules.add(rule);
                         }
                     }
@@ -217,6 +217,22 @@ public class NotificationRouter implements Subscriber {
                 }
             }
         }
+    }
+
+    private boolean checkChildren(Project parent, UUID uuid){
+        boolean isChild = false;
+        if (parent.getChildren() == null || parent.getChildren().isEmpty()){
+            return false;
+        } else {
+            for (Project child : parent.getChildren()){
+                if ((child.getUuid().equals(uuid) && child.isActive()) || isChild){
+                    return true;
+                } else {
+                    isChild = checkChildren(child, uuid);
+                }
+            }
+        }
+        return isChild;
     }
 
 }

--- a/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
@@ -298,6 +298,78 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         assertThat(router.resolveRules(notification)).isEmpty();
     }
 
+    @Test
+    public void testAffectedChild() {
+        NotificationPublisher publisher = createSlackPublisher();
+        // Creates a new rule and defines when the rule should be triggered (notifyOn)
+        NotificationRule rule = qm.createNotificationRule("Matching Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        Set<NotificationGroup> notifyOn = new HashSet<>();
+        notifyOn.add(NotificationGroup.NEW_VULNERABILITY);
+        rule.setNotifyOn(notifyOn);
+        // Creates a project which will later be matched on
+        List<Project> projects = new ArrayList<>();
+        Project grandParent = qm.createProject("Test Project Grandparent", null, "1.0", null, null, null, true, false);
+        Project parent = qm.createProject("Test Project Parent", null, "1.0", null, grandParent, null, true, false);
+        Project child = qm.createProject("Test Project Child", null, "1.0", null, parent, null, true, false);
+        Project grandChild = qm.createProject("Test Project Grandchild", null, "1.0", null, child, null, true, false);
+        projects.add(grandParent);
+        rule.setProjects(projects);
+        // Creates a new component
+        Component component = new Component();
+        component.setProject(grandChild);
+        // Creates a new notification
+        Notification notification = new Notification();
+        notification.setScope(NotificationScope.PORTFOLIO.name());
+        notification.setGroup(NotificationGroup.NEW_VULNERABILITY.name());
+        notification.setLevel(NotificationLevel.INFORMATIONAL);
+        // Notification should be limited to only specific projects - Set the projects which are affected by the notification event
+        Set<Project> affectedProjects = new HashSet<>();
+        affectedProjects.add(grandChild);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), component, affectedProjects);
+        notification.setSubject(subject);
+        // Ok, let's test this
+        NotificationRouter router = new NotificationRouter();
+        List<NotificationRule> rules = router.resolveRules(notification);
+        Assert.assertEquals(1, rules.size());
+    }
+
+    @Test
+    public void testAffectedInactiveChild() {
+        NotificationPublisher publisher = createSlackPublisher();
+        // Creates a new rule and defines when the rule should be triggered (notifyOn)
+        NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        Set<NotificationGroup> notifyOn = new HashSet<>();
+        notifyOn.add(NotificationGroup.NEW_VULNERABILITY);
+        rule.setNotifyOn(notifyOn);
+        // Creates a project which will later be matched on
+        List<Project> projects = new ArrayList<>();
+        Project grandParent = qm.createProject("Test Project Grandparent", null, "1.0", null, null, null, true, false);
+        Project parent = qm.createProject("Test Project Parent", null, "1.0", null, grandParent, null, true, false);
+        Project child = qm.createProject("Test Project Child", null, "1.0", null, parent, null, true, false);
+        Project grandChild = qm.createProject("Test Project Grandchild", null, "1.0", null, child, null, false, false);
+        projects.add(grandParent);
+        rule.setProjects(projects);
+        // Creates a new component
+        Component component = new Component();
+        component.setProject(grandChild);
+        // Creates a new notification
+        Notification notification = new Notification();
+        notification.setScope(NotificationScope.PORTFOLIO.name());
+        notification.setGroup(NotificationGroup.NEW_VULNERABILITY.name());
+        notification.setLevel(NotificationLevel.INFORMATIONAL);
+        // Notification should be limited to only specific projects - Set the projects which are affected by the notification event
+        Set<Project> affectedProjects = new HashSet<>();
+        affectedProjects.add(grandChild);
+        NewVulnerabilityIdentified subject = new NewVulnerabilityIdentified(new Vulnerability(), component, affectedProjects);
+        notification.setSubject(subject);
+        // Ok, let's test this
+        NotificationRouter router = new NotificationRouter();
+        List<NotificationRule> rules = router.resolveRules(notification);
+        Assert.assertEquals(0, rules.size());
+    }
+
+
+
     private NotificationPublisher createSlackPublisher() {
         return qm.createNotificationPublisher(
                 DefaultNotificationPublishers.SLACK.getPublisherName(),


### PR DESCRIPTION
Currently, when creating a limited alert rule you need to select every single version of a project. This does not work well for projects which create new versions regularly.
By automatically subscribing every child of a project to a notification rule, it is simpler to limit all existing versions or every future version of a project to a notification rule.

Signed-off-by: RBickert <rbt@mm-software.com>