### PR TITLE
Implement treegrid to display parent-child-relationship in project list

### DIFF
--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -24,6 +24,7 @@ import alpine.server.json.TrimmedStringDeserializer;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonIncludeProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -108,7 +109,6 @@ public class Project implements Serializable {
 
     @PrimaryKey
     @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
-    @JsonIgnore
     private long id;
 
     @Persistent
@@ -247,6 +247,11 @@ public class Project implements Serializable {
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     @JsonIgnore
     private List<Team> accessTeams;
+
+    @JsonProperty("pid")
+    private Long getParentId() {
+        return (this.getParent() == null)? null : this.getParent().getId();
+    }
 
     private transient ProjectMetrics metrics;
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -364,6 +364,13 @@ public class QueryManager extends AlpineQueryManager {
         return getProjectQueryManager().getChildrenProjects(uuid, includeMetrics, excludeInactive);
     }
 
+    public PaginatedResult getChildrenProjects(final Tag tag, final UUID uuid, final boolean includeMetrics, final boolean excludeInactive){
+        return getProjectQueryManager().getChildrenProjects(tag, uuid, includeMetrics, excludeInactive);
+    }
+
+    public PaginatedResult getChildrenProjects(final Classifier classifier, final UUID uuid, final boolean includeMetrics, final boolean excludeInactive){
+        return getProjectQueryManager().getChildrenProjects(classifier, uuid, includeMetrics, excludeInactive);
+    }
 
     public PaginatedResult getProjects(final Tag tag) {
         return getProjectQueryManager().getProjects(tag);

--- a/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -499,6 +499,7 @@ public class ProjectResource extends AlpineResource {
     )
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Access to the specified project is forbidden"),
             @ApiResponse(code = 404, message = "The UUID of the project could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
@@ -522,6 +523,82 @@ public class ProjectResource extends AlpineResource {
     }
 
     @GET
+    @Path("/{uuid}/children/classifier/{classifier}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Returns a list of all children for a project by classifier",
+            response = Project.class,
+            responseContainer = "List",
+            responseHeaders = @ResponseHeader(name = TOTAL_COUNT_HEADER, response = Long.class, description = "The total number of projects")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Access to the specified project is forbidden"),
+            @ApiResponse(code = 404, message = "The UUID of the project could not be found")
+    })
+    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
+    public Response getChildrenProjectsByClassifier(
+            @ApiParam(value = "The classifier to query on", required = true)
+            @PathParam("classifier") String classifierString,
+            @ApiParam(value = "The UUID of the project to get the children from", required = true)
+            @PathParam("uuid") String uuid,
+            @ApiParam(value = "Optionally excludes inactive projects from being returned", required = false)
+            @QueryParam("excludeInactive") boolean excludeInactive) {
+        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+            final Project project = qm.getObjectByUuid(Project.class, uuid);
+            if (project != null) {
+                final Classifier classifier = Classifier.valueOf(classifierString);
+                final PaginatedResult result = qm.getChildrenProjects(classifier, project.getUuid(), true, excludeInactive);
+                if (qm.hasAccess(super.getPrincipal(), project)) {
+                    return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
+                } else {
+                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                }
+            } else {
+                return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the project could not be found.").build();
+            }
+        }
+    }
+
+    @GET
+    @Path("/{uuid}/children/tag/{tag}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Returns a list of all children for a project by tag",
+            response = Project.class,
+            responseContainer = "List",
+            responseHeaders = @ResponseHeader(name = TOTAL_COUNT_HEADER, response = Long.class, description = "The total number of projects")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Access to the specified project is forbidden"),
+            @ApiResponse(code = 404, message = "The UUID of the project could not be found")
+    })
+    @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
+    public Response getChildrenProjectsByTag(
+            @ApiParam(value = "The tag to query on", required = true)
+            @PathParam("tag") String tagString,
+            @ApiParam(value = "The UUID of the project to get the children from", required = true)
+            @PathParam("uuid") String uuid,
+            @ApiParam(value = "Optionally excludes inactive projects from being returned", required = false)
+            @QueryParam("excludeInactive") boolean excludeInactive) {
+        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+            final Project project = qm.getObjectByUuid(Project.class, uuid);
+            if (project != null) {
+                final Tag tag = qm.getTagByName(tagString);
+                final PaginatedResult result = qm.getChildrenProjects(tag, project.getUuid(), true, excludeInactive);
+                if (qm.hasAccess(super.getPrincipal(), project)) {
+                    return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
+                } else {
+                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                }
+            } else {
+                return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the project could not be found.").build();
+            }
+        }
+    }
+
+    @GET
     @Path("/withoutDescendantsOf/{uuid}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
@@ -532,6 +609,7 @@ public class ProjectResource extends AlpineResource {
     )
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Access to the specified project is forbidden"),
             @ApiResponse(code = 404, message = "The UUID of the project could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)


### PR DESCRIPTION
[Frontend PR](https://github.com/rbt-mm/frontend/pull/4)

Adds new functionalities in the backend to display the multi-level parent-child-relationships in the project list via treegrid.

- A project now serializes its ID and its parent ID to JSON
- The API allows to get children projects by tag or by classifier

![hierarchical view active](https://user-images.githubusercontent.com/113189967/201305140-39e9879e-9e6e-43a4-9fee-ff7aa60ea720.png)

![hierarchical view inactive](https://user-images.githubusercontent.com/113189967/201305154-ee1e1bc3-8f71-4f01-b4c2-7dcd65239881.png)

![flat view](https://user-images.githubusercontent.com/113189967/201305168-ec95f5a8-1ea1-42db-a4cb-fac27b1579d7.png)

![create project](https://user-images.githubusercontent.com/113189967/201305320-fbd48323-c608-47e1-a602-119385a19c8c.png)

![detail view](https://user-images.githubusercontent.com/113189967/201305212-5caf80cd-88c8-42dd-af53-7d3ab35d3406.png)

Signed-off-by: RBickert <rbt@mm-software.com>