### PR TITLE
Create or delete new custom licenses using license API

### DIFF
--- a/src/main/java/org/dependencytrack/model/License.java
+++ b/src/main/java/org/dependencytrack/model/License.java
@@ -66,6 +66,7 @@ import java.util.UUID;
                 @Persistent(name = "osiApproved"),
                 @Persistent(name = "fsfLibre"),
                 @Persistent(name = "deprecatedLicenseId"),
+                @Persistent(name = "customLicense"),
                 @Persistent(name = "seeAlso"),
                 @Persistent(name = "licenseGroups"),
                 @Persistent(name = "uuid"),
@@ -75,6 +76,7 @@ import java.util.UUID;
                 @Persistent(name = "licenseId"),
                 @Persistent(name = "osiApproved"),
                 @Persistent(name = "fsfLibre"),
+                @Persistent(name = "customLicense")
         })
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -155,6 +157,7 @@ public class License implements Serializable {
     @JsonAlias(value = "licenseExceptionId")
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Size(min = 1, max = 255)
+    @NotBlank
     @Pattern(regexp = RegexSequence.Definition.STRING_IDENTIFIER, message = "The licenseId may only contain alpha, numeric, and specific symbols _-.+")
     private String licenseId;
 
@@ -181,6 +184,14 @@ public class License implements Serializable {
     @Column(name = "ISDEPRECATED")
     @JsonProperty(value = "isDeprecatedLicenseId")
     private boolean deprecatedLicenseId;
+
+    /**
+     * Identifies if the license is a custom license created by a user.
+     */
+    @Persistent(defaultFetchGroup = "true")
+    @Column(name = "ISCUSTOMLICENSE", allowsNull = "true") // New column, must allow nulls on existing databases
+    @JsonProperty(value = "isCustomLicense")
+    private boolean customLicense;
 
     /**
      * The seeAlso field - may contain URLs to the original license info.
@@ -286,6 +297,15 @@ public class License implements Serializable {
 
     public void setDeprecatedLicenseId(boolean deprecatedLicenseId) {
         this.deprecatedLicenseId = deprecatedLicenseId;
+    }
+
+
+    public boolean isCustomLicense() {
+        return customLicense;
+    }
+
+    public void setCustomLicense(boolean customLicense) {
+        this.customLicense = customLicense;
     }
 
     public String[] getSeeAlso() {

--- a/src/main/java/org/dependencytrack/persistence/LicenseQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/LicenseQueryManager.java
@@ -152,4 +152,67 @@ final class LicenseQueryManager extends QueryManager implements IQueryManager {
         }
         return result;
     }
+
+    /**
+     * Creates a new license.
+     * @param licenseId the license ID of the license to create (i.e. LicenseRef-scancode-ms-enterprise-library-eula)
+     * @param name the name of the license to create
+     * @param text the content of the license
+     * @param header the standard license header typically added to the top of source code
+     * @param template the standard license template typically used for the creation of the license text
+     * @param isOsiApproved Identifies if the license is approved by the OSI
+     * @param isFsfLibre specifies if the license is FSF Libre
+     * @param isDeprecatedLicenseId specifies if the licenseId has been deprecated by SPDX
+     * @param isCustomLicense specifies if the license has been created by a user
+     * @param comment a comment about the license. Typically includes release date, etc
+     * @param seeAlso the seeAlso field - may contain URLs to the original license info
+     * @param commitIndex specifies if the search index should be committed (an expensive operation)
+     * @return the created license
+     */
+    public License createLicense (String licenseId, String name, String text, String header, String template, boolean isOsiApproved, boolean isFsfLibre, boolean isDeprecatedLicenseId, boolean isCustomLicense, String comment, String seeAlso, boolean commitIndex) {
+        License license = new License();
+
+        license.setLicenseId(licenseId);
+        license.setName(name);
+        license.setText(text);
+        license.setHeader(header);
+        license.setTemplate(template);
+        license.setOsiApproved(isOsiApproved);
+        license.setFsfLibre(isFsfLibre);
+        license.setDeprecatedLicenseId(isDeprecatedLicenseId);
+        license.setCustomLicense(isCustomLicense);
+        license.setComment(comment);
+        license.setSeeAlso(seeAlso);
+
+        final License result = persist(license);
+
+        Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, pm.detachCopy(result)));
+        commitSearchIndex(commitIndex, License.class);
+
+        return result;
+    }
+
+    /**
+     * Creates a new custom license.
+     * @param license the license to create
+     * @param commitIndex specifies if the search index should be committed (an expensive operation)
+     * @return the created license
+     */
+    public License createCustomLicense(License license, boolean commitIndex) {
+        license.setCustomLicense(true);
+        final License result = persist(license);
+        Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, pm.detachCopy(result)));
+        commitSearchIndex(commitIndex, License.class);
+        return result;
+    }
+
+    /**
+     * Deletes a license.
+     * @param license the license to delete
+     * @param commitIndex specifies if the search index should be committed (an expensive operation)
+     */
+    public void deleteLicense(final License license, final boolean commitIndex) {
+        commitSearchIndex(commitIndex, License.class);
+        delete(license);
+    }
 }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -510,6 +510,18 @@ public class QueryManager extends AlpineQueryManager {
         return getLicenseQueryManager().synchronizeLicense(license, commitIndex);
     }
 
+    public License createLicense(String licenseId, String name, String text, String header, String template, boolean isOsiApproved, boolean isFsfLibre, boolean isDeprecatedLicenseId, boolean isCustomLicense, String comment, String seeAlso, boolean commitIndex) {
+        return getLicenseQueryManager().createLicense(licenseId, name, text, header, template, isOsiApproved, isFsfLibre, isDeprecatedLicenseId, isCustomLicense, comment, seeAlso, commitIndex);
+    }
+
+    public License createCustomLicense(License license, boolean commitIndex) {
+        return getLicenseQueryManager().createCustomLicense(license, commitIndex);
+    }
+
+    public void deleteLicense(final License license, final boolean commitIndex) {
+        getLicenseQueryManager().deleteLicense(license, commitIndex);
+    }
+
     public PaginatedResult getPolicies() {
         return getPolicyQueryManager().getPolicies();
     }

--- a/src/main/java/org/dependencytrack/resources/v1/LicenseResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/LicenseResource.java
@@ -30,13 +30,12 @@ import io.swagger.annotations.ResponseHeader;
 import org.dependencytrack.model.License;
 import org.dependencytrack.persistence.QueryManager;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.validation.Validator;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import alpine.common.logging.Logger;
 
 /**
  * JAX-RS resources for processing licenses.
@@ -47,6 +46,8 @@ import java.util.List;
 @Path("/v1/license")
 @Api(value = "license", authorizations = @Authorization(value = "X-Api-Key"))
 public class LicenseResource extends AlpineResource {
+
+    private static final Logger LOGGER = Logger.getLogger(LicenseResource.class);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -102,6 +103,65 @@ public class LicenseResource extends AlpineResource {
             final License license = qm.getLicense(licenseId);
             if (license != null) {
                 return Response.ok(license).build();
+            } else {
+                return Response.status(Response.Status.NOT_FOUND).entity("The license could not be found.").build();
+            }
+        }
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Creates a new custom license",
+            response = License.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 409, message = "A license with the specified ID already exists.")
+    })
+    public Response createLicense(License jsonLicense) {
+        final Validator validator = super.getValidator();
+        failOnValidationError(
+                validator.validateProperty(jsonLicense, "name"),
+                validator.validateProperty(jsonLicense, "licenseId")
+        );
+        try (QueryManager qm = new QueryManager()) {
+            License license = qm.getLicense(jsonLicense.getLicenseId());
+            if (license == null){
+                license = qm.createCustomLicense(jsonLicense, true);
+                LOGGER.info("License " + license.getName() + " created by " + super.getPrincipal().getName());
+                return Response.status(Response.Status.CREATED).entity(license).build();
+            } else {
+                return Response.status(Response.Status.CONFLICT).entity("A license with the specified name already exists.").build();
+            }
+        }
+    }
+
+    @DELETE
+    @Path("/{licenseId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Deletes a custom license",
+            code = 204
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 404, message = "The license could not be found"),
+            @ApiResponse(code = 409, message = "Only custom licenses can be deleted.")
+    })
+    public Response deleteLicense(
+            @ApiParam(value = "The SPDX License ID of the license to delete", required = true)
+            @PathParam("licenseId") String licenseId) {
+        try (QueryManager qm = new QueryManager()) {
+            final License license = qm.getLicense(licenseId);
+            if (license != null) {
+                if (Boolean.TRUE.equals(license.isCustomLicense())) {
+                    LOGGER.info("License " + license + " deletion request by " + super.getPrincipal().getName());
+                    qm.deleteLicense(license, true);
+                    return Response.status(Response.Status.NO_CONTENT).build();
+                } else {
+                    return Response.status(Response.Status.CONFLICT).entity("Only custom licenses can be deleted.").build();
+                }
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The license could not be found.").build();
             }

--- a/src/test/java/org/dependencytrack/model/LicenseTest.java
+++ b/src/test/java/org/dependencytrack/model/LicenseTest.java
@@ -97,6 +97,13 @@ public class LicenseTest {
     }
 
     @Test
+    public void testCustomLicense() {
+        License license = new License();
+        license.setCustomLicense(true);
+        Assert.assertTrue(license.isCustomLicense());
+    }
+
+    @Test
     public void testSeeAlso() {
         License license = new License();
         license.setSeeAlso("url #1", "url #2");

--- a/src/test/java/org/dependencytrack/resources/v1/LicenseResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/LicenseResourceTest.java
@@ -18,9 +18,11 @@
  */
 package org.dependencytrack.resources.v1;
 
+import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import org.dependencytrack.ResourceTest;
+import org.dependencytrack.model.License;
 import org.dependencytrack.persistence.DefaultObjectGenerator;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
@@ -32,6 +34,8 @@ import org.junit.Test;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 public class LicenseResourceTest extends ResourceTest {
@@ -107,5 +111,78 @@ public class LicenseResourceTest extends ResourceTest {
         Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
         Assert.assertEquals("The license could not be found.", body);
+    }
+
+    @Test
+    public void createCustomLicense() {
+        License license = new License();
+        license.setName("Acme Example");
+        license.setLicenseId("Acme-Example-License");
+        Response response = target(V1_LICENSE)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(license, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(201, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals("Acme Example", json.getString("name"));
+        Assert.assertEquals("Acme-Example-License", json.getString("licenseId"));
+        Assert.assertFalse(json.getBoolean("isOsiApproved"));
+        Assert.assertFalse(json.getBoolean("isFsfLibre"));
+        Assert.assertFalse(json.getBoolean("isDeprecatedLicenseId"));
+        Assert.assertTrue(json.getBoolean("isCustomLicense"));
+        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+    }
+
+    @Test
+    public void createCustomLicenseDuplicate() {
+        License license = new License();
+        license.setName("Apache License 2.0");
+        license.setLicenseId("Apache-2.0");
+        Response response = target(V1_LICENSE)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(license, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(409, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("A license with the specified name already exists.", body);
+    }
+
+    @Test
+    public void createCustomLicenseWithoutLicenseId() {
+        License license = new License();
+        license.setName("Acme Example");
+        Response response = target(V1_LICENSE)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(license, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(400, response.getStatus(), 0);
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+    }
+
+    @Test
+    public void deleteCustomLicense() {
+        License license = qm.createLicense("Acme-Example-License", "Acme Example", null, null, null, false, false, false, true, null, null, false);
+        Response response = target(V1_LICENSE + "/" + license.getLicenseId())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        Assert.assertEquals(204, response.getStatus(), 0);
+        Assert.assertTrue(license.isCustomLicense());
+    }
+
+    @Test
+    public void deleteNotCustomLicense() {
+        License license = qm.createLicense("Acme-Example-License", "Acme Example", null, null, null, false, false, false, false, null, null, false);
+        Response response = target(V1_LICENSE + "/" + license.getLicenseId())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+        Assert.assertEquals(409, response.getStatus(), 0);
+        Assert.assertFalse(license.isCustomLicense());
+        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("Only custom licenses can be deleted.", body);
     }
 }


### PR DESCRIPTION
Currently, unresolved licenses are only supported if they come in on an SBOM. There's no possibility to specify them via the license API.

Adds a `PUT` method to the license API. The `PUT` method requires a license name and a license ID to create a new license. The newly created license will have a new attribute set to true, to identify it as a custom license.

Adds a `DELETE` method to the license API. The `DELETE` method requires the path of a license and is only able to delete licenses which are identifiable as custom licenses.