### PR TITLE
Focus on components in dependency graph and hide other nodes

### DIFF
--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -347,6 +347,10 @@ public class Component implements Serializable {
     @JsonIgnore
     private transient JsonObject cacheResult;
 
+    private transient List<Component> dependencyGraph;
+
+    private transient boolean expand;
+
     public long getId() {
         return id;
     }
@@ -750,6 +754,22 @@ public class Component implements Serializable {
 
     public void setCacheResult(JsonObject cacheResult) {
         this.cacheResult = cacheResult;
+    }
+
+    public List<Component> getDependencyGraph() {
+        return dependencyGraph;
+    }
+
+    public void setDependencyGraph(List<Component> dependencyGraph) {
+        this.dependencyGraph = dependencyGraph;
+    }
+
+    public boolean isExpand() {
+        return expand;
+    }
+
+    public void setExpand(boolean expand) {
+        this.expand = expand;
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -250,6 +250,9 @@ public class Project implements Serializable {
 
     private transient ProjectMetrics metrics;
 
+    @JsonIgnore
+    private transient List<Component> dependencyGraph;
+
     public long getId() {
         return id;
     }
@@ -452,6 +455,14 @@ public class Project implements Serializable {
             this.accessTeams = new ArrayList<>();
         }
         this.accessTeams.add(accessTeam);
+    }
+
+    public List<Component> getDependencyGraph() {
+        return dependencyGraph;
+    }
+
+    public void setDependencyGraph(List<Component> dependencyGraph) {
+        this.dependencyGraph = dependencyGraph;
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -556,6 +556,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             }
             getParentDependency(project, parentNodeComponent.getUuid().toString(), pathComponentsMap);
         }
+        project.setDependencyGraph(new ArrayList<>());
         if (!pathComponentsMap.isEmpty()){
             loadDependencyGraphPaths(pathComponentsMap, project, component.getUuid().toString());
         }
@@ -581,7 +582,6 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
     }
 
     private void loadDependencyGraphPaths(Map<String, Set<String>> pathComponentsMap, Project project, String searchDependency) {
-        project.setDependencyGraph(new ArrayList<>());
         JsonArray directDependencies = Json.createReader(new StringReader(project.getDirectDependencies())).readArray();
         for (JsonValue directDependency : directDependencies) {
             Component component = this.getObjectByUuid(Component.class, directDependency.asJsonObject().getString("uuid"));
@@ -591,7 +591,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             if (component.getDirectDependencies() != null && !component.getDirectDependencies().isEmpty()){
                 loadDependencyGraphPaths(pathComponentsMap, component, searchDependency);
             }
-            // Saves huge amount of data, because it excludes unnecessary fields in JSON serialization. Implement better way of excluding, if possible. (Reduces response size from ~2GB to ~31MB)
+            // Saves huge amount of data, because it excludes unnecessary fields in JSON serialization
             Component transientComponent = new Component();
             transientComponent.setUuid(component.getUuid());
             transientComponent.setName(component.getName());
@@ -619,7 +619,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
                     && directDependencyComponent.getDirectDependencies() != null && !directDependencyComponent.getDirectDependencies().isBlank()){
                 loadDependencyGraphPaths(pathComponentsMap, directDependencyComponent, searchDependency);
             }
-            // Saves huge amount of data, because it excludes unnecessary fields in JSON serialization. Implement better way of excluding, if possible. (Reduces response size from ~2GB to ~31MB)
+            // Saves huge amount of data, because it excludes unnecessary fields in JSON serialization
             Component transientComponent = new Component();
             transientComponent.setUuid(directDependencyComponent.getUuid());
             transientComponent.setName(directDependencyComponent.getName());

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -542,6 +542,10 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
     }
 
     public List<Component> getDependencyGraphForComponent(Project project, Component component) {
+        project.setDependencyGraph(new ArrayList<>());
+        if (project.getDirectDependencies() == null || project.getDirectDependencies().isBlank()) {
+            return project.getDependencyGraph();
+        }
         String queryUuid = "\".*" + component.getUuid().toString() + ".*\"";
         final Query<Component> query = pm.newQuery(Component.class, "project == :project && directDependencies.matches(" + queryUuid + ")");
         List<Component> components = (List<Component>) query.executeWithArray(project);
@@ -556,7 +560,11 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             }
             getParentDependency(project, parentNodeComponent.getUuid().toString(), pathComponentsMap);
         }
-        project.setDependencyGraph(new ArrayList<>());
+        if (pathComponentsMap.isEmpty() && project.getDirectDependencies().contains(component.getUuid().toString())){
+            Set<String> set = new HashSet<>();
+            set.add(component.getUuid().toString());
+            pathComponentsMap.put(project.getUuid().toString(), set);
+        }
         if (!pathComponentsMap.isEmpty()){
             loadDependencyGraphPaths(pathComponentsMap, project, component.getUuid().toString());
         }

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -37,10 +37,16 @@ import org.dependencytrack.model.RepositoryType;
 import javax.jdo.FetchPlan;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+import javax.json.Json;
+import javax.json.JsonValue;
+import javax.json.JsonArray;
 
 final class ComponentQueryManager extends QueryManager implements IQueryManager {
 
@@ -532,6 +538,98 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             }
         } else {
             query.setFilter(inputFilter);
+        }
+    }
+
+    public List<Component> getDependencyGraphForComponent(Project project, Component component) {
+        String queryUuid = "\".*" + component.getUuid().toString() + ".*\"";
+        final Query<Component> query = pm.newQuery(Component.class, "project == :project && directDependencies.matches(" + queryUuid + ")");
+        List<Component> components = (List<Component>) query.executeWithArray(project);
+        Map<String, Set<String>> pathComponentsMap = new HashMap<>();
+        for (Component parentNodeComponent : components) {
+            if (pathComponentsMap.containsKey(parentNodeComponent.getUuid().toString())) {
+                pathComponentsMap.get(parentNodeComponent.getUuid().toString()).add(component.getUuid().toString());
+            } else {
+                Set<String> set = new HashSet<>();
+                set.add(component.getUuid().toString());
+                pathComponentsMap.put(parentNodeComponent.getUuid().toString(), set);
+            }
+            getParentDependency(project, parentNodeComponent.getUuid().toString(), pathComponentsMap);
+        }
+        if (!pathComponentsMap.isEmpty()){
+            loadDependencyGraphPaths(pathComponentsMap, project, component.getUuid().toString());
+        }
+        return project.getDependencyGraph();
+    }
+
+    private void getParentDependency(Project project, String uuid, Map<String, Set<String>> pathComponentsMap) {
+        String queryUuid = "\".*" + uuid + ".*\"";
+        final Query<Component> query = pm.newQuery(Component.class, "project == :project && directDependencies.matches(" + queryUuid + ")");
+        List<Component> components = (List<Component>) query.executeWithArray(project);
+        for (Component component : components) {
+            if (pathComponentsMap.containsKey(component.getUuid().toString())) {
+                if (pathComponentsMap.get(component.getUuid().toString()).add(uuid)) {
+                    getParentDependency(project, component.getUuid().toString(), pathComponentsMap);
+                }
+            } else {
+                Set<String> set = new HashSet<>();
+                set.add(uuid);
+                pathComponentsMap.put(component.getUuid().toString(), set);
+                getParentDependency(project, component.getUuid().toString(), pathComponentsMap);
+            }
+        }
+    }
+
+    private void loadDependencyGraphPaths(Map<String, Set<String>> pathComponentsMap, Project project, String searchDependency) {
+        project.setDependencyGraph(new ArrayList<>());
+        JsonArray directDependencies = Json.createReader(new StringReader(project.getDirectDependencies())).readArray();
+        for (JsonValue directDependency : directDependencies) {
+            Component component = this.getObjectByUuid(Component.class, directDependency.asJsonObject().getString("uuid"));
+            if (pathComponentsMap.containsKey(component.getUuid().toString()) && !component.getUuid().toString().equals(searchDependency)) {
+                component.setExpand(true);
+            }
+            if (component.getDirectDependencies() != null && !component.getDirectDependencies().isEmpty()){
+                loadDependencyGraphPaths(pathComponentsMap, component, searchDependency);
+            }
+            // Saves huge amount of data, because it excludes unnecessary fields in JSON serialization. Implement better way of excluding, if possible. (Reduces response size from ~2GB to ~31MB)
+            Component transientComponent = new Component();
+            transientComponent.setUuid(component.getUuid());
+            transientComponent.setName(component.getName());
+            transientComponent.setVersion(component.getVersion());
+            transientComponent.setDirectDependencies(component.getDirectDependencies());
+            transientComponent.setPurlCoordinates(component.getPurlCoordinates());
+            transientComponent.setDependencyGraph(component.getDependencyGraph());
+            transientComponent.setExpand(component.isExpand());
+
+            project.getDependencyGraph().add(transientComponent);
+        }
+    }
+
+    private void loadDependencyGraphPaths(Map<String, Set<String>> pathComponentsMap, Component component, String searchDependency) {
+        component.setDependencyGraph(new ArrayList<>());
+        JsonArray directDependencies = Json.createReader(new StringReader(component.getDirectDependencies())).readArray();
+        for (JsonValue directDependency : directDependencies) {
+            Component directDependencyComponent = this.getObjectByUuid(Component.class, directDependency.asJsonObject().getString("uuid"));
+            if (pathComponentsMap.containsKey(directDependencyComponent.getUuid().toString()) && !directDependencyComponent.getUuid().toString().equals(searchDependency)) {
+                directDependencyComponent.setExpand(true);
+            }
+            if (( pathComponentsMap.containsKey(directDependencyComponent.getUuid().toString()) || pathComponentsMap.containsKey(component.getUuid().toString()) )
+                    && !(pathComponentsMap.get(component.getUuid().toString()) != null && pathComponentsMap.get(component.getUuid().toString()).contains(directDependencyComponent.getUuid().toString())
+                    && pathComponentsMap.get(directDependencyComponent.getUuid().toString()) != null && pathComponentsMap.get(directDependencyComponent.getUuid().toString()).contains(component.getUuid().toString()))
+                    && directDependencyComponent.getDirectDependencies() != null && !directDependencyComponent.getDirectDependencies().isBlank()){
+                loadDependencyGraphPaths(pathComponentsMap, directDependencyComponent, searchDependency);
+            }
+            // Saves huge amount of data, because it excludes unnecessary fields in JSON serialization. Implement better way of excluding, if possible. (Reduces response size from ~2GB to ~31MB)
+            Component transientComponent = new Component();
+            transientComponent.setUuid(directDependencyComponent.getUuid());
+            transientComponent.setName(directDependencyComponent.getName());
+            transientComponent.setVersion(directDependencyComponent.getVersion());
+            transientComponent.setDirectDependencies(directDependencyComponent.getDirectDependencies());
+            transientComponent.setPurlCoordinates(directDependencyComponent.getPurlCoordinates());
+            transientComponent.setDependencyGraph(directDependencyComponent.getDependencyGraph());
+            transientComponent.setExpand(directDependencyComponent.isExpand());
+
+            component.getDependencyGraph().add(transientComponent);
         }
     }
 }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -495,6 +495,10 @@ public class QueryManager extends AlpineQueryManager {
         getComponentQueryManager().recursivelyDelete(component, commitIndex);
     }
 
+    public List<Component> getDependencyGraphForComponent(Project project, Component component) {
+        return getComponentQueryManager().getDependencyGraphForComponent(project, component);
+    }
+
     public PaginatedResult getLicenses() {
         return getLicenseQueryManager().getLicenses();
     }

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -422,7 +422,7 @@ public class ComponentResource extends AlpineResource {
     }
 
     @GET
-    @Path("/dependencyGraph/{componentUuid}/project/{projectUuid}")
+    @Path("/project/{projectUuid}/dependencyGraph/{componentUuid}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
             value = "Returns the expanded dependency graph to every occurrence of a component",
@@ -431,8 +431,7 @@ public class ComponentResource extends AlpineResource {
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Unauthorized"),
             @ApiResponse(code = 403, message = "Access to the specified project is forbidden"),
-            @ApiResponse(code = 404, message = "- The UUID of the project could not be found\n- The UUID of the component could not be found"),
-            @ApiResponse(code = 409, message = "The component is not part of the dependency Graph")
+            @ApiResponse(code = 404, message = "- The UUID of the project could not be found\n- The UUID of the component could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
     public Response getDependencyGraphForComponent(
@@ -449,11 +448,7 @@ public class ComponentResource extends AlpineResource {
                 final Component component = qm.getObjectByUuid(Component.class, componentUuid);
                 if (component != null) {
                     List<Component> components = qm.getDependencyGraphForComponent(project, component);
-                    if (components == null || components.isEmpty()){
-                        return Response.status(Response.Status.CONFLICT).entity("The component is not part of the dependency Graph.").build();
-                    } else {
-                        return Response.ok(components).build();
-                    }
+                    return Response.ok(components).build();
                 } else {
                     return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the component could not be found.").build();
                 }


### PR DESCRIPTION
### Description

Adds a new API method in the backend, which returns a list of all components that are necessary to display a dependency graph that is expanded to every occurrence of a specified component.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
1997
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

**Note:**
All of the data for the expanded dependency graph must be gathered in the backend, because the lazy-loading behavior of the dependency graph in the frontend would take way too many API requests to pre-expand a big graph with many occurences of a specified dependency.

[Frontend PR](https://github.com/rbt-mm/frontend/pull/6)

![Screenshot 2022-11-23 131931](https://user-images.githubusercontent.com/113189967/203545728-a61d38af-86c4-4d31-9961-3f3bc10ba81d.png)

![image](https://user-images.githubusercontent.com/113189967/203546899-27b5c7fa-e330-46eb-a7b6-90193dfb24b6.png)

![image](https://user-images.githubusercontent.com/113189967/203547007-c70e3ade-7648-4893-bba5-2260ae1ea6cd.png)

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
