### PR TITLE
Enable to set undefined license for license policy

### DIFF
--- a/src/main/java/org/dependencytrack/policy/LicensePolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/LicensePolicyEvaluator.java
@@ -52,19 +52,25 @@ public class LicensePolicyEvaluator extends AbstractPolicyEvaluator {
     public List<PolicyConditionViolation> evaluate(final Policy policy, final Component component) {
         final List<PolicyConditionViolation> violations = new ArrayList<>();
         final License license = component.getResolvedLicense();
-        if (license == null) {
-            return violations;
-        }
+
         for (final PolicyCondition condition: super.extractSupportedConditions(policy)) {
             LOGGER.debug("Evaluating component (" + component.getUuid() + ") against policy condition (" + condition.getUuid() + ")");
-            final License l = qm.getObjectByUuid(License.class, condition.getValue());
-            if (l != null && PolicyCondition.Operator.IS == condition.getOperator()) {
-                if (component.getResolvedLicense().getId() == l.getId()) {
+            if (condition.getValue().equals("undefinedLicense")) {
+                if (license == null && PolicyCondition.Operator.IS == condition.getOperator()) {
+                    violations.add(new PolicyConditionViolation(condition, component));
+                } else if (license != null && PolicyCondition.Operator.IS_NOT == condition.getOperator()) {
                     violations.add(new PolicyConditionViolation(condition, component));
                 }
-            } else if (l != null && PolicyCondition.Operator.IS_NOT == condition.getOperator()) {
-                if (component.getResolvedLicense().getId() != l.getId()) {
-                    violations.add(new PolicyConditionViolation(condition, component));
+            } else if (license != null) {
+                final License l = qm.getObjectByUuid(License.class, condition.getValue());
+                if (l != null && PolicyCondition.Operator.IS == condition.getOperator()) {
+                    if (component.getResolvedLicense().getId() == l.getId()) {
+                        violations.add(new PolicyConditionViolation(condition, component));
+                    }
+                } else if (l != null && PolicyCondition.Operator.IS_NOT == condition.getOperator()) {
+                    if (component.getResolvedLicense().getId() != l.getId()) {
+                        violations.add(new PolicyConditionViolation(condition, component));
+                    }
                 }
             }
         }

--- a/src/test/java/org/dependencytrack/policy/LicensePolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/LicensePolicyEvaluatorTest.java
@@ -102,4 +102,28 @@ public class LicensePolicyEvaluatorTest extends PersistenceCapableTest {
         Assert.assertEquals(0, violations.size());
     }
 
+    @Test
+    public void valueIsUndefinedLicense() {
+        License license = new License();
+        license.setName("Apache 2.0");
+        license.setLicenseId("Apache-2.0");
+        license.setUuid(UUID.randomUUID());
+        license = qm.persist(license);
+
+        Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.LICENSE, PolicyCondition.Operator.IS, "undefinedLicense");
+
+        Component componentWithLicense = new Component();
+        componentWithLicense.setResolvedLicense(license);
+
+        Component componentWithoutLicense = new Component();
+
+        PolicyEvaluator evaluator = new LicensePolicyEvaluator();
+        List<PolicyConditionViolation> violations = evaluator.evaluate(policy, componentWithLicense);
+        Assert.assertEquals(0, violations.size());
+
+        violations = evaluator.evaluate(policy, componentWithoutLicense);
+        Assert.assertEquals(1, violations.size());
+    }
+
 }


### PR DESCRIPTION
### Description

If you want to set up a license policy where the license is blank or null, it is currently only possible by creating a license policy which includes every single license. This is tedious to set up and needs to be maintained if new licenses are added.

To simplify setting up this license policy, it is now possible to choose `undefinedLicense` as the value for a policy condition. This condition then checks, if a component does not have a license.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

1518

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

![image](https://user-images.githubusercontent.com/113189967/204807269-04eac497-c1ea-47d8-8672-e185951009c2.png)

[Frontend PR](https://github.com/rbt-mm/frontend/pull/8)

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
