### PR TITLE
Display version status in `Audit Vulnerabilities` and `Exploit Predictions` tab

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.persistence;
 
 import alpine.resources.AlpineRequest;
+import com.github.packageurl.PackageURL;
 import org.datanucleus.api.jdo.JDOQuery;
 import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalysisComment;
@@ -30,6 +31,8 @@ import org.dependencytrack.model.Finding;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
+import org.dependencytrack.model.RepositoryType;
+import org.dependencytrack.model.RepositoryMetaComponent;
 
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
@@ -278,6 +281,14 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
                 // These are CLOB fields. Handle these here so that database-specific deserialization doesn't need to be performed (in Finding)
                 finding.getVulnerability().put("description", vulnerability.getDescription());
                 finding.getVulnerability().put("recommendation", vulnerability.getRecommendation());
+                final PackageURL purl = component.getPurl();
+                if (purl != null) {
+                    final RepositoryType type = RepositoryType.resolve(purl);
+                    if (RepositoryType.UNSUPPORTED != type) {
+                        final RepositoryMetaComponent repoMetaComponent = getRepositoryMetaComponent(type, purl.getNamespace(), purl.getName());
+                        finding.getComponent().put("latestVersion", repoMetaComponent.getLatestVersion());
+                    }
+                }
                 findings.add(finding);
             }
         }


### PR DESCRIPTION
### Description

Information about the version status of a component is currently only displayed in the `Components` tab of a project.

Also adding this information to the `Audit Vulnerabilities` and the `Exploit Predictions` tab of a project improves the usability of those two tabs, because it is no longer needed to switch tabs to check for version status information.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

New Issue in the frontend will be created after this PR is merged.

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

The retrieved `Finding` objects from `/finding/project/<projectUUID>` must be appended by the latest version of a component to correctly display the information in the UI.


[Frontend PR](https://github.com/rbt-mm/frontend/pull/12)

![image](https://user-images.githubusercontent.com/113189967/206444203-2e74d284-5fc9-4941-a5a6-21a38c389192.png)

![image](https://user-images.githubusercontent.com/113189967/206444334-c144fcc7-96b9-4ff3-9f37-987b86959570.png)

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
~- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective~
~- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
~- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
