### PR TITLE
Show version status information on dependency graph nodes

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -612,7 +612,12 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             transientComponent.setPurlCoordinates(component.getPurlCoordinates());
             transientComponent.setDependencyGraph(component.getDependencyGraph());
             transientComponent.setExpandDependencyGraph(component.isExpandDependencyGraph());
-
+            transientComponent.setPurl(component.getPurl());
+            final RepositoryType type = RepositoryType.resolve(transientComponent.getPurl());
+            if (RepositoryType.UNSUPPORTED != type) {
+                final RepositoryMetaComponent repoMetaComponent = getRepositoryMetaComponent(type, transientComponent.getPurl().getNamespace(), transientComponent.getPurl().getName());
+                transientComponent.setRepositoryMeta(repoMetaComponent);
+            }
             project.getDependencyGraph().add(transientComponent);
         }
     }
@@ -640,7 +645,12 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             transientComponent.setPurlCoordinates(directDependencyComponent.getPurlCoordinates());
             transientComponent.setDependencyGraph(directDependencyComponent.getDependencyGraph());
             transientComponent.setExpandDependencyGraph(directDependencyComponent.isExpandDependencyGraph());
-
+            transientComponent.setPurl(directDependencyComponent.getPurl());
+            final RepositoryType type = RepositoryType.resolve(transientComponent.getPurl());
+            if (RepositoryType.UNSUPPORTED != type) {
+                final RepositoryMetaComponent repoMetaComponent = getRepositoryMetaComponent(type, transientComponent.getPurl().getNamespace(), transientComponent.getPurl().getName());
+                transientComponent.setRepositoryMeta(repoMetaComponent);
+            }
             component.getDependencyGraph().add(transientComponent);
         }
     }

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -613,10 +613,12 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             transientComponent.setDependencyGraph(component.getDependencyGraph());
             transientComponent.setExpandDependencyGraph(component.isExpandDependencyGraph());
             transientComponent.setPurl(component.getPurl());
-            final RepositoryType type = RepositoryType.resolve(transientComponent.getPurl());
-            if (RepositoryType.UNSUPPORTED != type) {
-                final RepositoryMetaComponent repoMetaComponent = getRepositoryMetaComponent(type, transientComponent.getPurl().getNamespace(), transientComponent.getPurl().getName());
-                transientComponent.setRepositoryMeta(repoMetaComponent);
+            if (transientComponent.getPurl() != null) {
+                final RepositoryType type = RepositoryType.resolve(transientComponent.getPurl());
+                if (RepositoryType.UNSUPPORTED != type) {
+                    final RepositoryMetaComponent repoMetaComponent = getRepositoryMetaComponent(type, transientComponent.getPurl().getNamespace(), transientComponent.getPurl().getName());
+                    transientComponent.setRepositoryMeta(repoMetaComponent);
+                }
             }
             project.getDependencyGraph().add(transientComponent);
         }
@@ -646,10 +648,12 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             transientComponent.setDependencyGraph(directDependencyComponent.getDependencyGraph());
             transientComponent.setExpandDependencyGraph(directDependencyComponent.isExpandDependencyGraph());
             transientComponent.setPurl(directDependencyComponent.getPurl());
-            final RepositoryType type = RepositoryType.resolve(transientComponent.getPurl());
-            if (RepositoryType.UNSUPPORTED != type) {
-                final RepositoryMetaComponent repoMetaComponent = getRepositoryMetaComponent(type, transientComponent.getPurl().getNamespace(), transientComponent.getPurl().getName());
-                transientComponent.setRepositoryMeta(repoMetaComponent);
+            if (transientComponent.getPurl() != null) {
+                final RepositoryType type = RepositoryType.resolve(transientComponent.getPurl());
+                if (RepositoryType.UNSUPPORTED != type) {
+                    final RepositoryMetaComponent repoMetaComponent = getRepositoryMetaComponent(type, transientComponent.getPurl().getNamespace(), transientComponent.getPurl().getName());
+                    transientComponent.setRepositoryMeta(repoMetaComponent);
+                }
             }
             component.getDependencyGraph().add(transientComponent);
         }

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -40,6 +40,8 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
 import org.dependencytrack.model.License;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.RepositoryType;
+import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.InternalComponentIdentificationUtil;
 
@@ -115,13 +117,22 @@ public class ComponentResource extends AlpineResource {
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
     public Response getComponentByUuid(
             @ApiParam(value = "The UUID of the component to retrieve", required = true)
-            @PathParam("uuid") String uuid) {
+            @PathParam("uuid") String uuid,
+            @ApiParam(value = "Optionally includes third-party metadata about the component from external repositories", required = false)
+            @QueryParam("includeRepositoryMetaData") boolean includeRepositoryMetaData) {
         try (QueryManager qm = new QueryManager()) {
             final Component component = qm.getObjectByUuid(Component.class, uuid);
             if (component != null) {
                 final Project project = component.getProject();
                 if (qm.hasAccess(super.getPrincipal(), project)) {
                     final Component detachedComponent = qm.detach(Component.class, component.getId()); // TODO: Force project to be loaded. It should be anyway, but JDO seems to be having issues here.
+                    if (includeRepositoryMetaData) {
+                        final RepositoryType type = RepositoryType.resolve(detachedComponent.getPurl());
+                        if (RepositoryType.UNSUPPORTED != type) {
+                            final RepositoryMetaComponent repoMetaComponent = qm.getRepositoryMetaComponent(type, detachedComponent.getPurl().getNamespace(), detachedComponent.getPurl().getName());
+                            detachedComponent.setRepositoryMeta(repoMetaComponent);
+                        }
+                    }
                     return Response.ok(detachedComponent).build();
                 } else {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();


### PR DESCRIPTION
### Description

The information about the version status of a component is currently not displayed in the dependency graph, forcing users to switch to a different project tab, if they want to know about the version status.

This PR enhances the dependency graph to optionally display the version status information of a component on its corresponding node.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

New Issue in the frontend will be created after this PR is merged.

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

[Frontend PR](https://github.com/rbt-mm/frontend/pull/15)

**Note:** For the sake of better readability, the version status icon will only be shown for outdated components.

![image](https://user-images.githubusercontent.com/113189967/207022827-32d33561-3ae6-4aa6-9395-0e0acf3d5ae6.png)

![image](https://user-images.githubusercontent.com/113189967/207022754-4a329d88-4401-4de6-bf7c-740829444d06.png)

![image](https://user-images.githubusercontent.com/113189967/207023206-0845d932-b76c-43a7-badc-686f1ccaf1b0.png)

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
~- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective~
~- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
~- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
