### PR TITLE
Update `BOM_PROCESSING_FAILED` notification to include project URL and exception message

### DIFF
--- a/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -30,6 +30,7 @@ import org.dependencytrack.notification.publisher.Publisher;
 import org.dependencytrack.notification.publisher.SendMailPublisher;
 import org.dependencytrack.notification.vo.AnalysisDecisionChange;
 import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
+import org.dependencytrack.notification.vo.BomProcessingFailed;
 import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
 import org.dependencytrack.notification.vo.NewVulnerableDependency;
 import org.dependencytrack.notification.vo.PolicyViolationIdentified;
@@ -174,6 +175,9 @@ public class NotificationRouter implements Subscriber {
                 limitToProject(rules, result, notification, subject.getComponent().getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() instanceof final BomConsumedOrProcessed subject) {
+                limitToProject(rules, result, notification, subject.getProject());
+            } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
+                    && notification.getSubject() instanceof final BomProcessingFailed subject) {
                 limitToProject(rules, result, notification, subject.getProject());
             } else if (NotificationScope.PORTFOLIO.name().equals(notification.getScope())
                     && notification.getSubject() instanceof final VexConsumedOrProcessed subject) {

--- a/src/main/java/org/dependencytrack/notification/publisher/Publisher.java
+++ b/src/main/java/org/dependencytrack/notification/publisher/Publisher.java
@@ -29,6 +29,7 @@ import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.vo.AnalysisDecisionChange;
 import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
+import org.dependencytrack.notification.vo.BomProcessingFailed;
 import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
 import org.dependencytrack.notification.vo.NewVulnerableDependency;
 import org.dependencytrack.notification.vo.PolicyViolationIdentified;
@@ -113,6 +114,9 @@ public interface Publisher {
                     context.put("subject", subject);
                     context.put("subjectJson", NotificationUtil.toJson(subject));
                 } else if (notification.getSubject() instanceof final BomConsumedOrProcessed subject) {
+                    context.put("subject", subject);
+                    context.put("subjectJson", NotificationUtil.toJson(subject));
+                } else if (notification.getSubject() instanceof final BomProcessingFailed subject) {
                     context.put("subject", subject);
                     context.put("subjectJson", NotificationUtil.toJson(subject));
                 } else if (notification.getSubject() instanceof final VexConsumedOrProcessed subject) {

--- a/src/main/java/org/dependencytrack/notification/vo/BomProcessingFailed.java
+++ b/src/main/java/org/dependencytrack/notification/vo/BomProcessingFailed.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.dependencytrack.notification.vo;
+
+import org.dependencytrack.model.Project;
+
+public class BomProcessingFailed {
+
+    private Project project;
+    private String bom;
+    private String exception;
+
+    public BomProcessingFailed(final Project project, final String bom, final String exception) {
+        this.project = project;
+        this.bom = bom;
+        this.exception = exception;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public String getBom() {
+        return bom;
+    }
+
+    public String getException() {
+        return exception;
+    }
+}

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -43,6 +43,7 @@ import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.notification.publisher.DefaultNotificationPublishers;
 import org.dependencytrack.notification.vo.AnalysisDecisionChange;
 import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
+import org.dependencytrack.notification.vo.BomProcessingFailed;
 import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
 import org.dependencytrack.notification.vo.NewVulnerableDependency;
 import org.dependencytrack.notification.vo.PolicyViolationIdentified;
@@ -438,6 +439,20 @@ public final class NotificationUtil {
                     .add("format", vo.getFormat().getFormatShortName())
                     .add("specVersion", vo.getSpecVersion()).build()
             );
+        }
+        return builder.build();
+    }
+
+    public static JsonObject toJson(final BomProcessingFailed vo) {
+        final JsonObjectBuilder builder = Json.createObjectBuilder();
+        if (vo.getProject() != null) {
+            builder.add("project", toJson(vo.getProject()));
+        }
+        if (vo.getBom() != null) {
+            builder.add("bom", vo.getBom());
+        }
+        if (vo.getException() != null) {
+            builder.add("exception", vo.getException());
         }
         return builder.build();
     }

--- a/src/main/resources/templates/notification/publisher/email.peb
+++ b/src/main/resources/templates/notification/publisher/email.peb
@@ -75,6 +75,16 @@ Project:           {{ subject.project.name }}
 Version:           {{ subject.project.version }}
 Description:       {{ subject.project.description }}
 Project URL:       {{ baseUrl }}/projects/{{ subject.project.uuid }}
+{% elseif notification.group == "BOM_PROCESSING_FAILED" %}
+Project:           {{ subject.project.name }}
+Version:           {{ subject.project.version }}
+Description:       {{ subject.project.description }}
+Project URL:       {{ baseUrl }}/projects/{{ subject.project.uuid }}
+
+--------------------------------------------------------------------------------
+
+Exception:
+{{ subject.exception }}
 {% elseif notification.group == "VEX_CONSUMED" %}
 Project:           {{ subject.project.name }}
 Version:           {{ subject.project.version }}

--- a/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
+++ b/src/test/java/org/dependencytrack/notification/NotificationRouterTest.java
@@ -33,6 +33,7 @@ import org.dependencytrack.notification.publisher.DefaultNotificationPublishers;
 import org.dependencytrack.notification.publisher.Publisher;
 import org.dependencytrack.notification.vo.AnalysisDecisionChange;
 import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
+import org.dependencytrack.notification.vo.BomProcessingFailed;
 import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
 import org.dependencytrack.notification.vo.NewVulnerableDependency;
 import org.dependencytrack.notification.vo.PolicyViolationIdentified;
@@ -399,6 +400,31 @@ public class NotificationRouterTest extends PersistenceCapableTest {
         assertThat(router.resolveRules(notification)).isEmpty();
 
         notification.setSubject(new BomConsumedOrProcessed(projectA, "", Bom.Format.CYCLONEDX, ""));
+        assertThat(router.resolveRules(notification))
+                .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
+    }
+
+    @Test
+    public void testBomProcessingFailedLimitedToProject() {
+        final Project projectA = qm.createProject("Project A", null, "1.0", null, null, null, true, false);
+        final Project projectB = qm.createProject("Project B", null, "1.0", null, null, null, true, false);
+
+        final NotificationPublisher publisher = createSlackPublisher();
+
+        final NotificationRule rule = qm.createNotificationRule("Test Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        rule.setNotifyOn(Set.of(NotificationGroup.BOM_PROCESSING_FAILED));
+        rule.setProjects(List.of(projectA));
+
+        final var notification = new Notification();
+        notification.setScope(NotificationScope.PORTFOLIO.name());
+        notification.setGroup(NotificationGroup.BOM_PROCESSING_FAILED.name());
+        notification.setLevel(NotificationLevel.INFORMATIONAL);
+        notification.setSubject(new BomProcessingFailed(projectB, "", null));
+
+        final var router = new NotificationRouter();
+        assertThat(router.resolveRules(notification)).isEmpty();
+
+        notification.setSubject(new BomProcessingFailed(projectA, "", null));
         assertThat(router.resolveRules(notification))
                 .satisfiesExactly(resolvedRule -> assertThat(resolvedRule.getName()).isEqualTo("Test Rule"));
     }


### PR DESCRIPTION
Updated the `BOM_PROCESSING_FAILED` notification to include the project URL and the exception message.

Also added a test for limiting the notification to projects.

New notification:
![Screenshot 2023-03-14 181009](https://user-images.githubusercontent.com/113189967/225084591-9c3ab972-858a-4323-8b39-9382f626256a.png)