### PR TITLE
Add "Show in Dependency-Graph" Button in "Affected Projects" List

### DIFF
--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -264,6 +264,8 @@ public class Project implements Serializable {
     @JsonIgnore
     private transient List<Component> dependencyGraph;
 
+    private transient UUID affectedComponent;
+
     public long getId() {
         return id;
     }
@@ -490,6 +492,14 @@ public class Project implements Serializable {
 
     public void setDependencyGraph(List<Component> dependencyGraph) {
         this.dependencyGraph = dependencyGraph;
+    }
+
+    public UUID getAffectedComponent() {
+        return affectedComponent;
+    }
+
+    public void setAffectedComponent(UUID affectedComponent) {
+        this.affectedComponent = affectedComponent;
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -483,7 +483,9 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
                 affected = false;
             }
             if (affected) {
-                projects.add(component.getProject());
+                Project project = component.getProject();
+                project.setAffectedComponent(component.getUuid());
+                projects.add(project);
             }
         }
         // Force removal of duplicates by taking the List and populating a Set and back again.

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -211,7 +211,7 @@ public class VulnerabilityResource extends AlpineResource {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Vulnerability vulnerability = qm.getVulnerabilityByVulnId(source, vuln);
             if (vulnerability != null) {
-                final List<Project> projects = qm.detach(qm.getProjects(vulnerability));
+                final List<Project> projects = qm.getProjects(vulnerability);
                 final long totalCount = projects.size();
                 return Response.ok(projects).header(TOTAL_COUNT_HEADER, totalCount).build();
             } else {

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -258,6 +258,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertNotNull(json);
         Assert.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
         Assert.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
+        Assert.assertEquals(sampleData.c1.getUuid().toString(), json.getJsonObject(0).getString("affectedComponent"));
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR adds the `Show in Dependency-Graph` button to the every project in the `Affected Projects` tab of a vulnerability, but only if the affected project has a dependency graph.
Clicking the button redirects the user to the projects dependency graph and highlights the affected component.

### Addressed Issue

Frontend 533

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
~- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended~
~- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
